### PR TITLE
fix: When the login configuration cannot be obtained, Email, Google, …

### DIFF
--- a/apps/web/src/pages/authentication/sign-in.tsx
+++ b/apps/web/src/pages/authentication/sign-in.tsx
@@ -84,15 +84,17 @@ export const SignIn = () => {
     window.location.href = `${apiUrl}/api/auth/${provider}`;
   };
 
-  const isEmailAuthEnabled = data?.getAuthConfig.some(
-    (item: AuthConfigItem) => item.provider === 'email',
-  );
-  const isGithubAuthEnabled = data?.getAuthConfig.some(
-    (item: AuthConfigItem) => item.provider === 'github',
-  );
-  const isGoogleAuthEnabled = data?.getAuthConfig.some(
-    (item: AuthConfigItem) => item.provider === 'google',
-  );
+  // Show all auth options by default when config is loading
+  // Only disable if explicitly set to false in config
+  const isEmailAuthEnabled =
+    !data?.getAuthConfig ||
+    data.getAuthConfig.some((item: AuthConfigItem) => item.provider === 'email');
+  const isGithubAuthEnabled =
+    !data?.getAuthConfig ||
+    data.getAuthConfig.some((item: AuthConfigItem) => item.provider === 'github');
+  const isGoogleAuthEnabled =
+    !data?.getAuthConfig ||
+    data.getAuthConfig.some((item: AuthConfigItem) => item.provider === 'google');
 
   return (
     <Form {...form}>


### PR DESCRIPTION
…and Github are enabled by default.:

#16 