### PR TITLE
Fix: display avatar images instead avatar fallbacks for admin environment switcher items

### DIFF
--- a/apps/web/src/pages/layouts/components/admin-env-switcher.tsx
+++ b/apps/web/src/pages/layouts/components/admin-env-switcher.tsx
@@ -5,7 +5,7 @@ import { useEnvironmentListContext } from '@/contexts/environment-list-context';
 import { EnvironmentCreateForm } from '@/pages/settings/environments/components/environment-create-form';
 import { Environment } from '@/types/project';
 import { CheckIcon, PlusCircledIcon } from '@radix-ui/react-icons';
-import { Avatar, AvatarFallback, AvatarImage } from '@usertour-ui/avatar';
+import { Avatar, AvatarFallback } from '@usertour-ui/avatar';
 import { Button } from '@usertour-ui/button';
 import {
   Command,
@@ -83,13 +83,15 @@ export const AdminEnvSwitcher = () => {
                     }}
                     className="text-sm"
                   >
-                    <Avatar className="mr-2 h-5 w-5">
-                      <AvatarImage
+                    <Avatar className="mr-2 h-6 w-6">
+                      {/* <AvatarImage
                         src="https://avatar.vercel.sh/acme-inc.png"
                         alt={env.name}
                         className="grayscale"
-                      />
-                      <AvatarFallback>SC</AvatarFallback>
+                      /> */}
+                      <AvatarFallback className="bg-blue-800 text-white text-xs">
+                        {environment?.name?.slice(0, 2)}
+                      </AvatarFallback>
                     </Avatar>
                     {env.name}
                     <CheckIcon


### PR DESCRIPTION
Replace grey avatar images with initials in admin environment switcher items as requested in  #114  

<img width="453" alt="image" src="https://github.com/user-attachments/assets/bc6092a3-c8cf-46ac-8316-c8bb5245da44" />
