### PR TITLE
refactor: add self-hosted mode check in team member validation

### DIFF
--- a/apps/server/src/team/team.service.ts
+++ b/apps/server/src/team/team.service.ts
@@ -97,6 +97,10 @@ export class TeamService {
   }
 
   private async validateTeamMemberLimit(projectId: string, subscriptionId: string | undefined) {
+    const isSelfHostedMode = this.configService.get('globalConfig.isSelfHostedMode');
+    if (isSelfHostedMode) {
+      return;
+    }
     if (!subscriptionId) {
       throw new TeamMemberLimitError();
     }


### PR DESCRIPTION
- Introduced a check for self-hosted mode in the validateTeamMemberLimit method to bypass subscription ID validation when in self-hosted mode.
- This change enhances the flexibility of team member management based on deployment configurations.