### PR TITLE
fix: update delete button disabled condition in ContentEditDropdownMenu

### DIFF
--- a/apps/web/src/pages/contents/components/shared/content-edit-dropmenu.tsx
+++ b/apps/web/src/pages/contents/components/shared/content-edit-dropmenu.tsx
@@ -71,7 +71,7 @@ export const ContentEditDropdownMenu = (props: ContentEditDropdownMenuProps) => 
           <DropdownMenuItem
             className="text-red-600 cursor-pointer"
             onClick={handleOnClick}
-            disabled={content.published || disabled}
+            disabled={isPublishedAtLeastOneEnvironment(content) || disabled}
           >
             <Delete2Icon className="mr-1" />
             Delete {content.type}


### PR DESCRIPTION
- Modified the disabled condition for the delete button to check if the content is published in at least one environment, improving the accuracy of the button's state based on content status.