### PR TITLE
fix: adjust maxItems calculation in PopperProgress for accurate step …

### DIFF
--- a/apps/sdk/package.json
+++ b/apps/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usertour/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "homepage": "https://www.usertour.io",
   "author": "Usertour, Inc.",

--- a/packages/shared/sdk/src/popper.tsx
+++ b/packages/shared/sdk/src/popper.tsx
@@ -802,7 +802,7 @@ const PopperProgress = forwardRef<HTMLDivElement, PopperProgresshProps>((props, 
   // currentStepIndex is 0-based, so we add 1 for display and progress calculation
   const displayStep = currentStepIndex + 1;
   const progressPercentage = totalSteps > 0 ? (displayStep / totalSteps) * 100 : 0;
-  const maxItems = Math.max(2, totalSteps);
+  const maxItems = totalSteps;
 
   if (type === ProgressBarType.NARROW) {
     return (


### PR DESCRIPTION
…representation

- Updated the maxItems calculation to directly use totalSteps instead of applying a minimum value, ensuring correct progress bar behavior.