### PR TITLE
chore: bump SDK version to 0.2.15 and simplify checklist activation l…

### DIFF
--- a/apps/sdk/package.json
+++ b/apps/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usertour/sdk",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "type": "module",
   "homepage": "https://www.usertour.io",
   "author": "Usertour, Inc.",

--- a/apps/sdk/src/core/app.ts
+++ b/apps/sdk/src/core/app.ts
@@ -748,7 +748,7 @@ export class App extends Evented {
       this.checklists.filter((checklist) => !checklist.isTemporarilyHidden()),
     );
 
-    if (latestActivatedChecklist && !latestActivatedChecklist.hasDismissed()) {
+    if (latestActivatedChecklist) {
       this.activeChecklist = latestActivatedChecklist;
       await this.activeChecklist.start(contentStartReason.START_FROM_SESSION);
       return true;


### PR DESCRIPTION
…ogic

- Updated SDK version from 0.2.14 to 0.2.15 in package.json.
- Simplified the condition for activating the latest checklist in app.ts by removing the check for dismissal status.