### PR TITLE
chore: bump SDK version to 0.2.27 and update content item handling

### DIFF
--- a/apps/sdk/package.json
+++ b/apps/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usertour/sdk",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "type": "module",
   "homepage": "https://www.usertour.io",
   "author": "Usertour, Inc.",

--- a/apps/sdk/src/utils/content-utils.ts
+++ b/apps/sdk/src/utils/content-utils.ts
@@ -73,7 +73,7 @@ export function initializeContentItems<T extends Tour | Launcher | Checklist>(
     const contentId = item.getContent().contentId;
     if (!contentIdMap.has(contentId)) {
       if (contentType === ContentDataType.LAUNCHER) {
-        item.close(contentEndReason.UNPUBLISHED_CONTENT);
+        item.destroy();
       } else {
         item.close(contentEndReason.UNPUBLISHED_CONTENT);
       }


### PR DESCRIPTION
- Updated SDK version to 0.2.27.
- Modified content item handling to replace item.close with item.destroy for unpublished content in content-utils.ts.