### PR TITLE
fix: ensure theme rename form is only displayed when theme is defined

### DIFF
--- a/apps/web/src/pages/settings/themes/components/preview/theme-preview-checklist.tsx
+++ b/apps/web/src/pages/settings/themes/components/preview/theme-preview-checklist.tsx
@@ -41,7 +41,9 @@ export const ThemePreviewChecklist = (props: ThemePreviewChecklistProps) => {
         expanded={expandedState}
         themeSettings={settings}
         zIndex={10000}
-        onExpandedChange={setExpandedState}
+        onExpandedChange={async (expanded: boolean) => {
+          setExpandedState(expanded);
+        }}
       >
         <ChecklistContainer>
           <ChecklistPopper zIndex={10000}>

--- a/apps/web/src/pages/settings/themes/components/theme-detail-header.tsx
+++ b/apps/web/src/pages/settings/themes/components/theme-detail-header.tsx
@@ -71,7 +71,7 @@ export const ThemeDetailHeader = () => {
             </span>
           </>
         )}
-        {!theme?.isSystem && (
+        {!theme?.isSystem && theme && (
           <ThemeRenameForm
             data={theme}
             onSubmit={() => {


### PR DESCRIPTION
- Updated the condition for rendering the ThemeRenameForm to check if the theme is defined in addition to not being a system theme, preventing potential errors in the UI.
- Modified the onExpandedChange handler in ThemePreviewChecklist to be asynchronous, improving state management during checklist expansion.