### PR TITLE
fix(admin-layout): add userTourToken check before initializing user t…

### DIFF
--- a/apps/web/src/pages/layouts/components/admin-layout.tsx
+++ b/apps/web/src/pages/layouts/components/admin-layout.tsx
@@ -138,12 +138,14 @@ const useUserTracking = (userInfo: any) => {
     if (!userInfo || !userInfo.id) {
       return;
     }
-    usertour.init(userTourToken);
-    usertour.identify(`${userInfo.id}`, {
-      name: userInfo?.name,
-      email: userInfo?.email,
-      signed_up_at: userInfo.createdAt,
-    });
+    if (userTourToken) {
+      usertour.init(userTourToken);
+      usertour.identify(`${userInfo.id}`, {
+        name: userInfo?.name,
+        email: userInfo?.email,
+        signed_up_at: userInfo.createdAt,
+      });
+    }
     posthog?.identify(userInfo.id, {
       email: userInfo.email,
     });


### PR DESCRIPTION
…racking

Ensured that user tracking initialization only occurs if userTourToken is present, preventing potential errors when the token is undefined.