### PR TITLE
fix(web): skip subscription query when project has no subscriptionId

### DIFF
--- a/apps/web/src/pages/settings/members/components/member-invite-dialog.tsx
+++ b/apps/web/src/pages/settings/members/components/member-invite-dialog.tsx
@@ -82,7 +82,9 @@ export const MemberInviteDialog = ({ onClose, isOpen }: InviteDialogProps) => {
   const { globalConfig } = useAppContext();
   const navigate = useNavigate();
 
-  const { subscription } = useGetSubscriptionByProjectIdQuery(project?.id);
+  const { subscription } = useGetSubscriptionByProjectIdQuery(project?.id, {
+    skip: !project?.id || !project?.subscriptionId,
+  });
 
   const planType: PlanType = subscription?.planType ?? PlanType.HOBBY;
 


### PR DESCRIPTION
Self-hosted and free-tier projects have no subscriptionId, which made the member invite dialog throw "No subscription found for project". Mirror the guard already used in SubscriptionProvider so the query is skipped instead of erroring.