### PR TITLE
fix(analytics): order Clicks by block tabs by RC configuration

### DIFF
--- a/apps/web/src/pages/contents/components/analytics/analytics-blocks.tsx
+++ b/apps/web/src/pages/contents/components/analytics/analytics-blocks.tsx
@@ -27,12 +27,14 @@ const groupBlocksByTab = (blocks: AnalyticsViewsByBlock[]): TabGroup[] => {
       });
     }
   }
-  return Array.from(groups.values())
-    .map((group) => ({
-      ...group,
-      blocks: [...group.blocks].sort((a, b) => b.analytics.totalClicks - a.analytics.totalClicks),
-    }))
-    .sort((a, b) => b.totalClicks - a.totalClicks);
+  // Tabs preserve the configured order from the published RC data
+  // (server returns viewsByBlock in tab/block iteration order, and Map
+  // keeps insertion order). Blocks within a tab are sorted by clicks DESC
+  // so the highest-volume blocks surface first in each tab.
+  return Array.from(groups.values()).map((group) => ({
+    ...group,
+    blocks: [...group.blocks].sort((a, b) => b.analytics.totalClicks - a.analytics.totalClicks),
+  }));
 };
 
 const getRankDotClass = (rank: number, isIdle: boolean) => {


### PR DESCRIPTION
Tabs in the Resource Center "Clicks by block" panel were sorted by total clicks descending, which made the order on the analytics page diverge from the order users see in the builder. Drop the tab-level sort and rely on the server's tab iteration order (Map insertion order preserves it on the client). Blocks within a tab still sort by clicks descending so the highest-volume blocks surface first.