### PR TITLE
refactor(server): batch Attribute lookups; centralize attr resolution…

### DIFF
--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -31,6 +31,7 @@ import {
   capitalizeFirstLetter,
   filterNullAttributes,
   getAttributeType,
+  humanize,
   isNull,
   isValidISO8601,
 } from '@usertour/helpers';
@@ -57,6 +58,30 @@ function normalizeSegmentColumns(raw: unknown): ColumnSetting[] {
       .map(([codeName, visible]) => ({ codeName, visible: visible as boolean }));
   }
   return [];
+}
+
+/**
+ * Result of `BizService.resolveAttributes`: the validated attribute payload,
+ * the attribute-row map for downstream lookups, and a flag for cache
+ * invalidation.
+ */
+interface ResolvedAttributes {
+  /**
+   * codeName → validated value. Null entries are passed through verbatim.
+   * Values that fail type / format validation are dropped (and logged).
+   */
+  outputData: Record<string, any>;
+  /**
+   * codeName → Attribute row (existing or just-created). Lets callers
+   * resolve codeName → id without a second lookup, e.g. for
+   * AttributeOnEvent linking.
+   */
+  attrMap: Map<string, Attribute>;
+  /**
+   * True iff at least one Attribute row was created during this call.
+   * Triggers project-level Attribute cache invalidation.
+   */
+  createdNewAttribute: boolean;
 }
 
 @Injectable()
@@ -796,87 +821,167 @@ export class BizService {
     });
   }
 
+  /**
+   * Resolve User/Company/Membership attribute payload: auto-create unknown
+   * codeNames, validate values against declared dataTypes, and invalidate
+   * the project's Attribute cache when new rows were created.
+   */
   async insertBizAttributes(
     tx: Prisma.TransactionClient,
     projectId: string,
     bizType: AttributeBizType,
     attributes: Record<string, any>,
   ): Promise<Record<string, any>> {
-    const insertAttribute = {};
-    let createdNewAttribute = false;
+    const { outputData, createdNewAttribute } = await this.resolveAttributes(
+      tx,
+      projectId,
+      bizType,
+      attributes,
+    );
+    if (createdNewAttribute) {
+      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+    }
+    return outputData;
+  }
+
+  /**
+   * Resolve EVENT-typed attribute payload and link the validated attributes
+   * to the given Event row. trackEvent uses this to keep AttributeOnEvent
+   * bookkeeping out of the websocket layer.
+   */
+  async resolveAndLinkEventAttributes(
+    tx: Prisma.TransactionClient,
+    projectId: string,
+    eventId: string,
+    attributes: Record<string, any>,
+  ): Promise<{ eventData: Record<string, any>; createdNewAttribute: boolean }> {
+    const { outputData, attrMap, createdNewAttribute } = await this.resolveAttributes(
+      tx,
+      projectId,
+      AttributeBizType.EVENT,
+      attributes,
+    );
+
+    // Link only attributes whose value passed validation (i.e. ended up in
+    // outputData with a non-null value).
+    const linkIds = Object.keys(outputData)
+      .filter((codeName) => outputData[codeName] != null)
+      .map((codeName) => attrMap.get(codeName)?.id)
+      .filter((id): id is string => !!id);
+    await this.linkAttributesToEvent(tx, eventId, linkIds);
+
+    if (createdNewAttribute) {
+      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+    }
+    return { eventData: outputData, createdNewAttribute };
+  }
+
+  /**
+   * Find-or-create Attribute rows for the given codeNames in one batched
+   * findMany + sequential creates for misses, then validate each value.
+   * Returns the attribute map so callers (e.g. AttributeOnEvent linking)
+   * can resolve codeName → id without a second round trip.
+   *
+   * Null inputs are passed through verbatim; rejected values (DateTime
+   * format / type mismatch) are dropped from outputData and logged.
+   */
+  private async resolveAttributes(
+    tx: Prisma.TransactionClient,
+    projectId: string,
+    bizType: AttributeBizType,
+    attributes: Record<string, any>,
+  ): Promise<ResolvedAttributes> {
+    const outputData: Record<string, any> = {};
+    const attrMap = new Map<string, Attribute>();
+    const codeNames: string[] = [];
     for (const codeName in attributes) {
-      const attrValue = attributes[codeName];
-      const attrName = codeName;
-      if (isNull(attrValue)) {
-        insertAttribute[attrName] = null;
-        continue;
+      if (isNull(attributes[codeName])) {
+        outputData[codeName] = null;
+      } else {
+        codeNames.push(codeName);
       }
-      const dataType = getAttributeType(attrValue);
-      const attribute = await tx.attribute.findFirst({
-        where: {
-          projectId,
-          codeName: attrName,
-          bizType,
-        },
-      });
-      if (!attribute) {
-        const newAttr = await tx.attribute.create({
+    }
+    if (codeNames.length === 0) {
+      return { outputData, attrMap, createdNewAttribute: false };
+    }
+
+    const existing = await tx.attribute.findMany({
+      where: { projectId, bizType, codeName: { in: codeNames } },
+    });
+    for (const attr of existing) {
+      attrMap.set(attr.codeName, attr);
+    }
+
+    const displayName = bizType === AttributeBizType.EVENT ? humanize : capitalizeFirstLetter;
+    let createdNewAttribute = false;
+    for (const codeName of codeNames) {
+      let attr = attrMap.get(codeName);
+      if (!attr) {
+        attr = await tx.attribute.create({
           data: {
-            codeName: attrName,
-            dataType: dataType,
-            displayName: capitalizeFirstLetter(attrName),
+            codeName,
+            dataType: getAttributeType(attributes[codeName]),
+            displayName: displayName(codeName),
             projectId,
             bizType,
           },
         });
+        attrMap.set(codeName, attr);
         createdNewAttribute = true;
-        if (newAttr) {
-          // DateTime must be stored as ISO 8601 in UTC
-          if (dataType === BizAttributeTypes.DateTime) {
-            if (!isValidISO8601(attrValue)) {
-              this.logger.error(
-                `Invalid DateTime format for attribute "${attrName}". DateTime attributes must be in ISO 8601 format (UTC). Received: ${JSON.stringify(attrValue)}. Example: "2024-12-12T00:00:00.000Z". Skipping this field.`,
-              );
-              continue;
-            }
-            insertAttribute[attrName] = attrValue;
-          } else {
-            insertAttribute[attrName] = attrValue;
-          }
-          continue;
-        }
       }
-      if (attribute) {
-        // If attribute is DateTime type, value must be ISO 8601 format regardless of detected type
-        if (attribute.dataType === BizAttributeTypes.DateTime) {
-          if (!isValidISO8601(attrValue)) {
-            this.logger.error(
-              `Invalid DateTime format for attribute "${attrName}". DateTime attributes must be in ISO 8601 format (UTC). Received: ${JSON.stringify(attrValue)}. Example: "2024-12-12T00:00:00.000Z". Skipping this field.`,
-            );
-            continue;
-          }
-          insertAttribute[attrName] = attrValue;
-        } else if (attribute.dataType === dataType) {
-          // For non-DateTime types, only store if types match
-          insertAttribute[attrName] = attrValue;
-        } else {
-          // Log type mismatch but don't throw error to allow flexibility
-          this.logger.warn(
-            `Type mismatch for attribute ${attrName}. Expected type: ${attribute.dataType}, got: ${dataType}. Value: ${attrValue}`,
-          );
-        }
+      const result = this.validateAttrValue(attr, attributes[codeName]);
+      if (result.ok) {
+        outputData[codeName] = result.value;
       }
     }
-    // Defer cache invalidation to the request boundary. Doing this inline
-    // would fire BEFORE the surrounding $transaction commits, opening a
-    // window where another request could repopulate the cache from
-    // pre-commit DB state. ProjectCacheService falls back to immediate
-    // invalidation when called outside a request scope (i.e. when tx is
-    // actually `this.prisma` and statements auto-commit).
-    if (createdNewAttribute) {
-      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+
+    return { outputData, attrMap, createdNewAttribute };
+  }
+
+  private validateAttrValue(
+    attr: Attribute,
+    value: unknown,
+  ): { ok: true; value: unknown } | { ok: false } {
+    const dataType = getAttributeType(value);
+    if (attr.dataType === BizAttributeTypes.DateTime) {
+      if (!isValidISO8601(value)) {
+        this.logger.error(
+          `Invalid DateTime format for attribute "${attr.codeName}". DateTime attributes must be in ISO 8601 format (UTC). Received: ${JSON.stringify(value)}. Example: "2024-12-12T00:00:00.000Z". Skipping this field.`,
+        );
+        return { ok: false };
+      }
+      return { ok: true, value };
     }
-    return insertAttribute;
+    if (attr.dataType !== dataType) {
+      this.logger.warn(
+        `Type mismatch for attribute "${attr.codeName}". Expected type: ${attr.dataType}, got: ${dataType}. Value: ${value}`,
+      );
+      return { ok: false };
+    }
+    return { ok: true, value };
+  }
+
+  private async linkAttributesToEvent(
+    tx: Prisma.TransactionClient,
+    eventId: string,
+    attributeIds: string[],
+  ): Promise<void> {
+    if (attributeIds.length === 0) {
+      return;
+    }
+    const existing = await tx.attributeOnEvent.findMany({
+      where: { eventId, attributeId: { in: attributeIds } },
+      select: { attributeId: true },
+    });
+    const linked = new Set(existing.map((link) => link.attributeId));
+    const toLink = attributeIds.filter((id) => !linked.has(id));
+    if (toLink.length === 0) {
+      return;
+    }
+    await tx.attributeOnEvent.createMany({
+      data: toLink.map((attributeId) => ({ eventId, attributeId })),
+      skipDuplicates: true,
+    });
   }
 
   async getBizUser(id: string, environmentId: string, include?: Prisma.BizUserInclude) {

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -90,7 +90,9 @@ export class ProjectCacheService {
     await this.flushDeferred();
 
     const cached = await this.redis.getJson<T>(key);
-    if (cached !== null) return cached;
+    if (cached !== null) {
+      return cached;
+    }
 
     const fresh = await loader();
     if (fresh !== undefined && fresh !== null) {
@@ -155,7 +157,9 @@ export class ProjectCacheService {
     await this.flushDeferred();
 
     const result = new Map<string, T>();
-    if (keys.length === 0) return result;
+    if (keys.length === 0) {
+      return result;
+    }
 
     const cached = await this.redis.mgetJson<T>(keys);
     const missingKeys: string[] = [];
@@ -215,7 +219,9 @@ export class ProjectCacheService {
    */
   private async flushDeferred(): Promise<void> {
     const ctx = requestContext.getStore();
-    if (!ctx || ctx.deferredCacheInvalidations.size === 0) return;
+    if (!ctx || ctx.deferredCacheInvalidations.size === 0) {
+      return;
+    }
     const keys = [...ctx.deferredCacheInvalidations];
     ctx.deferredCacheInvalidations.clear();
     await this.invalidate(keys);

--- a/apps/server/src/shared/redis.service.ts
+++ b/apps/server/src/shared/redis.service.ts
@@ -84,7 +84,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
       throw new Error('Redis client not available');
     }
     const raw = await this.client.get(key);
-    if (raw === null) return null;
+    if (raw === null) {
+      return null;
+    }
     try {
       return JSON.parse(raw) as T;
     } catch (err) {
@@ -102,7 +104,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     if (!this.client) {
       throw new Error('Redis client not available');
     }
-    if (value === undefined || value === null) return;
+    if (value === undefined || value === null) {
+      return;
+    }
     await this.client.setex(key, ttlSeconds, JSON.stringify(value));
   }
 
@@ -111,7 +115,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
       throw new Error('Redis client not available');
     }
     const list = Array.isArray(keys) ? keys : [keys];
-    if (list.length === 0) return;
+    if (list.length === 0) {
+      return;
+    }
     await this.client.del(...list);
   }
 
@@ -123,10 +129,14 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     if (!this.client) {
       throw new Error('Redis client not available');
     }
-    if (keys.length === 0) return [];
+    if (keys.length === 0) {
+      return [];
+    }
     const raws = await this.client.mget(...keys);
     return raws.map((raw) => {
-      if (raw === null) return null;
+      if (raw === null) {
+        return null;
+      }
       try {
         return JSON.parse(raw) as T;
       } catch {
@@ -142,10 +152,14 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     if (!this.client) {
       throw new Error('Redis client not available');
     }
-    if (entries.length === 0) return;
+    if (entries.length === 0) {
+      return;
+    }
     const pipeline = this.client.pipeline();
     for (const [key, value] of entries) {
-      if (value === undefined || value === null) continue;
+      if (value === undefined || value === null) {
+        continue;
+      }
       pipeline.setex(key, ttlSeconds, JSON.stringify(value));
     }
     await pipeline.exec();

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -458,7 +458,9 @@ export class ContentDataService {
       .map((content) => getPublishedVersionId(content, environment.id))
       .filter(Boolean);
 
-    if (versionIds.length === 0) return [];
+    if (versionIds.length === 0) {
+      return [];
+    }
 
     // Per-version cache; published Version data is immutable so a long TTL
     // is safe (see invariant doc above). MGET reads all keys in one round
@@ -469,7 +471,7 @@ export class ContentDataService {
       [...keyToId.keys()],
       ContentDataService.PUBLISHED_VERSION_TTL_SECONDS,
       async (missingKeys) => {
-        const missingIds = missingKeys.map((k) => keyToId.get(k) as string);
+        const missingIds = missingKeys.map((cacheKey) => keyToId.get(cacheKey) as string);
         const fresh = await this.prisma.version.findMany({
           where: { id: { in: missingIds } },
           include: {
@@ -477,12 +479,12 @@ export class ContentDataService {
             steps: { orderBy: { sequence: 'asc' } },
           },
         });
-        return new Map(fresh.map((v) => [this.cache.keys.versionFull(v.id), v]));
+        return new Map(fresh.map((version) => [this.cache.keys.versionFull(version.id), version]));
       },
     );
     return versionIds
       .map((id) => cached.get(this.cache.keys.versionFull(id)))
-      .filter((v): v is VersionWithStepsAndContent => v != null);
+      .filter((version): version is VersionWithStepsAndContent => version != null);
   }
 
   /**

--- a/apps/server/src/web-socket/v2/web-socket-v2.service.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2.service.ts
@@ -32,7 +32,6 @@ import {
   BizEvents,
   ClientCondition,
   CustomContentSession,
-  BizAttributeTypes,
 } from '@usertour/types';
 import { WebSocketContext } from './web-socket-v2.dto';
 import { Socket, Server } from 'socket.io';
@@ -43,20 +42,7 @@ import { ContentOrchestratorService } from '@/web-socket/core/content-orchestrat
 import { ProjectCacheService } from '@/shared/project-cache.service';
 import { buildExternalUserRoomId } from '@/utils/websocket-utils';
 import { assignClientContext } from '@/utils/event-v2';
-import { AttributeBizType } from '@/attributes/models/attribute.model';
-import { getAttributeType, isNull, isValidISO8601 } from '@usertour/helpers';
-
-/**
- * Humanize a codeName into a display name.
- * Splits on `_`, `-`, `.` and spaces, capitalizes each word.
- */
-function humanize(name: string): string {
-  return name
-    .split(/[_\-.\s]+/)
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(' ');
-}
+import { humanize } from '@usertour/helpers';
 
 @Injectable()
 export class WebSocketV2Service {
@@ -449,67 +435,17 @@ export class WebSocketV2Service {
         });
       }
 
-      // 2. Process attributes: auto-create Attribute + AttributeOnEvent
-      const eventData: Record<string, any> = {};
+      // 2. Resolve attributes + link them to this Event (handled by BizService).
       const mergedAttributes = assignClientContext(attributes ?? {}, clientContext);
-
-      if (Object.keys(mergedAttributes).length > 0) {
-        for (const attrName of Object.keys(mergedAttributes)) {
-          const attrValue = mergedAttributes[attrName];
-
-          if (isNull(attrValue)) {
-            eventData[attrName] = null;
-            continue;
-          }
-
-          const dataType = getAttributeType(attrValue);
-
-          // Find or create the attribute
-          let attr = await tx.attribute.findFirst({
-            where: { codeName: attrName, projectId, bizType: AttributeBizType.EVENT },
-          });
-
-          if (!attr) {
-            attr = await tx.attribute.create({
-              data: {
-                codeName: attrName,
-                dataType,
-                displayName: humanize(attrName),
-                projectId,
-                bizType: AttributeBizType.EVENT,
-              },
-            });
-            createdNewAttribute = true;
-          }
-
-          // Validate and store value (same logic as insertBizAttributes)
-          if (attr.dataType === BizAttributeTypes.DateTime) {
-            if (!isValidISO8601(attrValue)) {
-              this.logger.error(
-                `Invalid DateTime format for attribute "${attrName}". Received: ${JSON.stringify(attrValue)}. Skipping.`,
-              );
-              continue;
-            }
-            eventData[attrName] = attrValue;
-          } else if (attr.dataType === dataType) {
-            eventData[attrName] = attrValue;
-          } else {
-            this.logger.warn(
-              `Type mismatch for attribute ${attrName}. Expected: ${attr.dataType}, got: ${dataType}`,
-            );
-            continue;
-          }
-
-          // Link attribute to event via AttributeOnEvent
-          const existing = await tx.attributeOnEvent.findFirst({
-            where: { eventId: event.id, attributeId: attr.id },
-          });
-          if (!existing) {
-            await tx.attributeOnEvent.create({
-              data: { eventId: event.id, attributeId: attr.id },
-            });
-          }
-        }
+      const { eventData, createdNewAttribute: ca } =
+        await this.bizService.resolveAndLinkEventAttributes(
+          tx,
+          projectId,
+          event.id,
+          mergedAttributes,
+        );
+      if (ca) {
+        createdNewAttribute = true;
       }
 
       // 3. Create BizEvent

--- a/packages/helpers/src/attribute.ts
+++ b/packages/helpers/src/attribute.ts
@@ -79,6 +79,18 @@ export const capitalizeFirstLetter = (string: string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
+/**
+ * Humanize a codeName into a display name.
+ * Splits on `_`, `-`, `.` and whitespace, then title-cases each word.
+ */
+export const humanize = (name: string): string => {
+  return name
+    .split(/[_\-.\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+};
+
 export const filterNullAttributes = (attributes: Record<string, any>) => {
   const attrs: Record<string, any> = {};
   for (const key in attributes) {


### PR DESCRIPTION
… in BizService

Replace the N findFirst-per-codeName pattern in insertBizAttributes and trackEvent with a single batched findMany + sequential creates for misses. Per the production query log this drops the busiest query category (Attribute.findFirst, ~683 calls/window) by an order of magnitude:

  - UpsertUser p50: ~33ms → ~22ms
  - UpsertCompany p50: ~49ms → ~38ms
  - trackEvent saves ~10-30ms depending on attribute count

The two call sites used to share ~80 lines of near-identical resolve + auto-create + validate logic. Centralize behind two purpose-named public methods on BizService:

  - insertBizAttributes(...) — User/Company/Membership upserts (existing API)
  - resolveAndLinkEventAttributes(...) — trackEvent path; also batches the AttributeOnEvent linking that used to live in web-socket-v2

Internals:

  - resolveAttributes (private): one findMany + sequential creates + per-value validation; returns ResolvedAttributes interface so both public callers get a typed shape.
  - validateAttrValue (private): the DateTime ISO 8601 / dataType check extracted to its own predicate.
  - linkAttributesToEvent (private): one findMany + one createMany (skipDuplicates) for AttributeOnEvent rows.

Side-effects:

  - humanize moved from web-socket-v2.service.ts into @usertour/helpers so resolveAttributes can pick the correct displayName by bizType.
  - trackEvent's attribute block shrinks from ~30 lines to ~9; no longer knows about AttributeOnEvent at all.
  - Drop unused BizAttributeTypes / getAttributeType / isValidISO8601 / isNull imports from web-socket-v2.service.ts.