### PR TITLE
perf(server): SDK toggleContents — project cache + request-scoped memo

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -48,7 +48,6 @@ import { Logger } from '@nestjs/common';
       isGlobal: true,
       prismaServiceOptions: {
         middlewares: [
-          // Conditionally enable Prisma logging based on environment variable
           ...(process.env.ENABLE_PRISMA_LOGGING === 'true'
             ? [
                 loggingMiddleware({
@@ -58,6 +57,12 @@ import { Logger } from '@nestjs/common';
               ]
             : []),
         ],
+        // Engine-level query event so SQL inside $transaction(callback) is also visible.
+        // Middleware cannot intercept transactional operations.
+        prismaOptions:
+          process.env.ENABLE_PRISMA_LOGGING === 'true'
+            ? { log: [{ emit: 'event', level: 'query' }] }
+            : undefined,
       },
     }),
     LoggerModule.forRootAsync({

--- a/apps/server/src/attributes/attributes.module.ts
+++ b/apps/server/src/attributes/attributes.module.ts
@@ -1,11 +1,12 @@
 import { ProjectsModule } from '@/projects/projects.module';
+import { SharedModule } from '@/shared/shared.module';
 import { Module } from '@nestjs/common';
 import { AttributesGuard } from './attributes.guard';
 import { AttributesResolver } from './attributes.resolver';
 import { AttributesService } from './attributes.service';
 
 @Module({
-  imports: [ProjectsModule],
+  imports: [ProjectsModule, SharedModule],
   providers: [AttributesResolver, AttributesService, AttributesGuard],
   exports: [AttributesService],
 })

--- a/apps/server/src/attributes/attributes.service.ts
+++ b/apps/server/src/attributes/attributes.service.ts
@@ -14,7 +14,7 @@ export class AttributesService {
 
   async create(data: CreateAttributeInput) {
     const created = await this.prisma.attribute.create({ data });
-    this.cache.invalidateDeferred(this.cache.keys.attrs(created.projectId));
+    await this.cache.invalidateDeferred(this.cache.keys.attrs(created.projectId));
     return created;
   }
 
@@ -24,7 +24,7 @@ export class AttributesService {
       where: { id },
       data: { ...others },
     });
-    this.cache.invalidateDeferred(this.cache.keys.attrs(updated.projectId));
+    await this.cache.invalidateDeferred(this.cache.keys.attrs(updated.projectId));
     return updated;
   }
 
@@ -32,7 +32,7 @@ export class AttributesService {
     const deleted = await this.prisma.attribute.delete({
       where: { id },
     });
-    this.cache.invalidateDeferred(this.cache.keys.attrs(deleted.projectId));
+    await this.cache.invalidateDeferred(this.cache.keys.attrs(deleted.projectId));
     return deleted;
   }
 

--- a/apps/server/src/attributes/attributes.service.ts
+++ b/apps/server/src/attributes/attributes.service.ts
@@ -3,29 +3,37 @@ import { PrismaService } from 'nestjs-prisma';
 import { CreateAttributeInput, UpdateAttributeInput } from './dto/attribute.input';
 import { findManyCursorConnection } from '@devoxa/prisma-relay-cursor-connection';
 import { Prisma } from '@prisma/client';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 @Injectable()
 export class AttributesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly cache: ProjectCacheService,
+  ) {}
 
   async create(data: CreateAttributeInput) {
-    return await this.prisma.attribute.create({
-      data,
-    });
+    const created = await this.prisma.attribute.create({ data });
+    this.cache.invalidateDeferred(this.cache.keys.attrs(created.projectId));
+    return created;
   }
 
   async update(data: UpdateAttributeInput) {
     const { id, ...others } = data;
-    return await this.prisma.attribute.update({
+    const updated = await this.prisma.attribute.update({
       where: { id },
       data: { ...others },
     });
+    this.cache.invalidateDeferred(this.cache.keys.attrs(updated.projectId));
+    return updated;
   }
 
   async delete(id: string) {
-    return await this.prisma.attribute.delete({
+    const deleted = await this.prisma.attribute.delete({
       where: { id },
     });
+    this.cache.invalidateDeferred(this.cache.keys.attrs(deleted.projectId));
+    return deleted;
   }
 
   async get(id: string) {

--- a/apps/server/src/biz/biz.module.ts
+++ b/apps/server/src/biz/biz.module.ts
@@ -1,12 +1,13 @@
 import { EnvironmentsModule } from '@/environments/environments.module';
 import { ProjectsModule } from '@/projects/projects.module';
+import { SharedModule } from '@/shared/shared.module';
 import { Module } from '@nestjs/common';
 import { BizGuard } from './biz.guard';
 import { BizResolver } from './biz.resolver';
 import { BizService } from './biz.service';
 
 @Module({
-  imports: [EnvironmentsModule, ProjectsModule],
+  imports: [EnvironmentsModule, ProjectsModule, SharedModule],
   providers: [BizResolver, BizService, BizGuard],
   exports: [BizService],
 })

--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -643,13 +643,15 @@ export class BizService {
       where: { externalId: String(externalUserId), environmentId },
     });
     if (!user) {
-      return await tx.bizUser.create({
+      const created = await tx.bizUser.create({
         data: {
           externalId: String(externalUserId),
           environmentId,
           data: insertAttribute,
         },
       });
+      this.cache.invalidateMemo(this.cache.memoKeys.bizUser(environmentId, String(externalUserId)));
+      return created;
     }
     const currentData = (user.data as Record<string, any>) || {};
     const insertData = filterNullAttributes({
@@ -662,7 +664,7 @@ export class BizService {
       return user;
     }
 
-    return await tx.bizUser.update({
+    const updated = await tx.bizUser.update({
       where: {
         id: user.id,
       },
@@ -670,6 +672,13 @@ export class BizService {
         data: insertData,
       },
     });
+    // Drop the per-request memo so subsequent findBizUser reads (e.g. the
+    // toggleContents condition evaluation that fires right after a
+    // bindToAttribute write) see the fresh `data`. Without this the memo
+    // would serve the scope-entry snapshot and segment rules filtering on
+    // the just-written attribute would evaluate against the old value.
+    this.cache.invalidateMemo(this.cache.memoKeys.bizUser(environmentId, String(externalUserId)));
+    return updated;
   }
 
   async upsertBizCompanies(
@@ -754,7 +763,7 @@ export class BizService {
         return company;
       }
 
-      return await tx.bizCompany.update({
+      const updated = await tx.bizCompany.update({
         where: {
           id: company.id,
         },
@@ -762,15 +771,24 @@ export class BizService {
           data: mergedData,
         },
       });
+      // Drop the per-request memo so subsequent reads see fresh `data`.
+      this.cache.invalidateMemo(
+        this.cache.memoKeys.bizCompany(environmentId, String(externalCompanyId)),
+      );
+      return updated;
     }
 
-    return await tx.bizCompany.create({
+    const created = await tx.bizCompany.create({
       data: {
         externalId: String(externalCompanyId),
         environmentId,
         data: insertAttribute,
       },
     });
+    this.cache.invalidateMemo(
+      this.cache.memoKeys.bizCompany(environmentId, String(externalCompanyId)),
+    );
+    return created;
   }
 
   async upsertBizMembership(
@@ -803,7 +821,7 @@ export class BizService {
         return relation;
       }
 
-      return await tx.bizUserOnCompany.update({
+      const updated = await tx.bizUserOnCompany.update({
         where: {
           id: relation.id,
         },
@@ -811,14 +829,23 @@ export class BizService {
           data: mergedData,
         },
       });
+      // Drop both membership memos: the bare `bizUserOnCompany:bizUser:bizCompany`
+      // key is targeted, and `bizUserOnCompanyWithBizCompany:bizUser:...` is wiped
+      // by user prefix because we don't carry envId/externalCompanyId here.
+      this.cache.invalidateMemo(this.cache.memoKeys.bizUserOnCompany(bizUserId, bizCompanyId));
+      this.cache.invalidateMemoByPrefix([`bizUserOnCompanyWithBizCompany:${bizUserId}:`]);
+      return updated;
     }
-    return await tx.bizUserOnCompany.create({
+    const created = await tx.bizUserOnCompany.create({
       data: {
         bizUserId,
         bizCompanyId,
         data: insertAttribute,
       },
     });
+    this.cache.invalidateMemo(this.cache.memoKeys.bizUserOnCompany(bizUserId, bizCompanyId));
+    this.cache.invalidateMemoByPrefix([`bizUserOnCompanyWithBizCompany:${bizUserId}:`]);
+    return created;
   }
 
   /**

--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -31,6 +31,7 @@ import {
   capitalizeFirstLetter,
   filterNullAttributes,
   getAttributeType,
+  humanize,
   isNull,
   isValidISO8601,
 } from '@usertour/helpers';
@@ -57,6 +58,30 @@ function normalizeSegmentColumns(raw: unknown): ColumnSetting[] {
       .map(([codeName, visible]) => ({ codeName, visible: visible as boolean }));
   }
   return [];
+}
+
+/**
+ * Result of `BizService.resolveAttributes`: the validated attribute payload,
+ * the attribute-row map for downstream lookups, and a flag for cache
+ * invalidation.
+ */
+interface ResolvedAttributes {
+  /**
+   * codeName → validated value. Null entries are passed through verbatim.
+   * Values that fail type / format validation are dropped (and logged).
+   */
+  outputData: Record<string, any>;
+  /**
+   * codeName → Attribute row (existing or just-created). Lets callers
+   * resolve codeName → id without a second lookup, e.g. for
+   * AttributeOnEvent linking.
+   */
+  attrMap: Map<string, Attribute>;
+  /**
+   * True iff at least one Attribute row was created during this call.
+   * Triggers project-level Attribute cache invalidation.
+   */
+  createdNewAttribute: boolean;
 }
 
 @Injectable()
@@ -796,87 +821,167 @@ export class BizService {
     });
   }
 
+  /**
+   * Resolve User/Company/Membership attribute payload: auto-create unknown
+   * codeNames, validate values against declared dataTypes, and invalidate
+   * the project's Attribute cache when new rows were created.
+   */
   async insertBizAttributes(
     tx: Prisma.TransactionClient,
     projectId: string,
     bizType: AttributeBizType,
     attributes: Record<string, any>,
   ): Promise<Record<string, any>> {
-    const insertAttribute = {};
-    let createdNewAttribute = false;
+    const { outputData, createdNewAttribute } = await this.resolveAttributes(
+      tx,
+      projectId,
+      bizType,
+      attributes,
+    );
+    if (createdNewAttribute) {
+      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+    }
+    return outputData;
+  }
+
+  /**
+   * Resolve EVENT-typed attribute payload and link the validated attributes
+   * to the given Event row. trackEvent uses this to keep AttributeOnEvent
+   * bookkeeping out of the websocket layer.
+   */
+  async resolveAndLinkEventAttributes(
+    tx: Prisma.TransactionClient,
+    projectId: string,
+    eventId: string,
+    attributes: Record<string, any>,
+  ): Promise<{ eventData: Record<string, any>; createdNewAttribute: boolean }> {
+    const { outputData, attrMap, createdNewAttribute } = await this.resolveAttributes(
+      tx,
+      projectId,
+      AttributeBizType.EVENT,
+      attributes,
+    );
+
+    // Link only attributes whose value passed validation (i.e. ended up in
+    // outputData with a non-null value).
+    const linkIds = Object.keys(outputData)
+      .filter((codeName) => outputData[codeName] != null)
+      .map((codeName) => attrMap.get(codeName)?.id)
+      .filter((id): id is string => !!id);
+    await this.linkAttributesToEvent(tx, eventId, linkIds);
+
+    if (createdNewAttribute) {
+      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+    }
+    return { eventData: outputData, createdNewAttribute };
+  }
+
+  /**
+   * Find-or-create Attribute rows for the given codeNames in one batched
+   * findMany + sequential creates for misses, then validate each value.
+   * Returns the attribute map so callers (e.g. AttributeOnEvent linking)
+   * can resolve codeName → id without a second round trip.
+   *
+   * Null inputs are passed through verbatim; rejected values (DateTime
+   * format / type mismatch) are dropped from outputData and logged.
+   */
+  private async resolveAttributes(
+    tx: Prisma.TransactionClient,
+    projectId: string,
+    bizType: AttributeBizType,
+    attributes: Record<string, any>,
+  ): Promise<ResolvedAttributes> {
+    const outputData: Record<string, any> = {};
+    const attrMap = new Map<string, Attribute>();
+    const codeNames: string[] = [];
     for (const codeName in attributes) {
-      const attrValue = attributes[codeName];
-      const attrName = codeName;
-      if (isNull(attrValue)) {
-        insertAttribute[attrName] = null;
-        continue;
+      if (isNull(attributes[codeName])) {
+        outputData[codeName] = null;
+      } else {
+        codeNames.push(codeName);
       }
-      const dataType = getAttributeType(attrValue);
-      const attribute = await tx.attribute.findFirst({
-        where: {
-          projectId,
-          codeName: attrName,
-          bizType,
-        },
-      });
-      if (!attribute) {
-        const newAttr = await tx.attribute.create({
+    }
+    if (codeNames.length === 0) {
+      return { outputData, attrMap, createdNewAttribute: false };
+    }
+
+    const existing = await tx.attribute.findMany({
+      where: { projectId, bizType, codeName: { in: codeNames } },
+    });
+    for (const attr of existing) {
+      attrMap.set(attr.codeName, attr);
+    }
+
+    const displayName = bizType === AttributeBizType.EVENT ? humanize : capitalizeFirstLetter;
+    let createdNewAttribute = false;
+    for (const codeName of codeNames) {
+      let attr = attrMap.get(codeName);
+      if (!attr) {
+        attr = await tx.attribute.create({
           data: {
-            codeName: attrName,
-            dataType: dataType,
-            displayName: capitalizeFirstLetter(attrName),
+            codeName,
+            dataType: getAttributeType(attributes[codeName]),
+            displayName: displayName(codeName),
             projectId,
             bizType,
           },
         });
+        attrMap.set(codeName, attr);
         createdNewAttribute = true;
-        if (newAttr) {
-          // DateTime must be stored as ISO 8601 in UTC
-          if (dataType === BizAttributeTypes.DateTime) {
-            if (!isValidISO8601(attrValue)) {
-              this.logger.error(
-                `Invalid DateTime format for attribute "${attrName}". DateTime attributes must be in ISO 8601 format (UTC). Received: ${JSON.stringify(attrValue)}. Example: "2024-12-12T00:00:00.000Z". Skipping this field.`,
-              );
-              continue;
-            }
-            insertAttribute[attrName] = attrValue;
-          } else {
-            insertAttribute[attrName] = attrValue;
-          }
-          continue;
-        }
       }
-      if (attribute) {
-        // If attribute is DateTime type, value must be ISO 8601 format regardless of detected type
-        if (attribute.dataType === BizAttributeTypes.DateTime) {
-          if (!isValidISO8601(attrValue)) {
-            this.logger.error(
-              `Invalid DateTime format for attribute "${attrName}". DateTime attributes must be in ISO 8601 format (UTC). Received: ${JSON.stringify(attrValue)}. Example: "2024-12-12T00:00:00.000Z". Skipping this field.`,
-            );
-            continue;
-          }
-          insertAttribute[attrName] = attrValue;
-        } else if (attribute.dataType === dataType) {
-          // For non-DateTime types, only store if types match
-          insertAttribute[attrName] = attrValue;
-        } else {
-          // Log type mismatch but don't throw error to allow flexibility
-          this.logger.warn(
-            `Type mismatch for attribute ${attrName}. Expected type: ${attribute.dataType}, got: ${dataType}. Value: ${attrValue}`,
-          );
-        }
+      const result = this.validateAttrValue(attr, attributes[codeName]);
+      if (result.ok) {
+        outputData[codeName] = result.value;
       }
     }
-    // Defer cache invalidation to the request boundary. Doing this inline
-    // would fire BEFORE the surrounding $transaction commits, opening a
-    // window where another request could repopulate the cache from
-    // pre-commit DB state. ProjectCacheService falls back to immediate
-    // invalidation when called outside a request scope (i.e. when tx is
-    // actually `this.prisma` and statements auto-commit).
-    if (createdNewAttribute) {
-      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+
+    return { outputData, attrMap, createdNewAttribute };
+  }
+
+  private validateAttrValue(
+    attr: Attribute,
+    value: unknown,
+  ): { ok: true; value: unknown } | { ok: false } {
+    const dataType = getAttributeType(value);
+    if (attr.dataType === BizAttributeTypes.DateTime) {
+      if (!isValidISO8601(value)) {
+        this.logger.error(
+          `Invalid DateTime format for attribute "${attr.codeName}". DateTime attributes must be in ISO 8601 format (UTC). Received: ${JSON.stringify(value)}. Example: "2024-12-12T00:00:00.000Z". Skipping this field.`,
+        );
+        return { ok: false };
+      }
+      return { ok: true, value };
     }
-    return insertAttribute;
+    if (attr.dataType !== dataType) {
+      this.logger.warn(
+        `Type mismatch for attribute "${attr.codeName}". Expected type: ${attr.dataType}, got: ${dataType}. Value: ${value}`,
+      );
+      return { ok: false };
+    }
+    return { ok: true, value };
+  }
+
+  private async linkAttributesToEvent(
+    tx: Prisma.TransactionClient,
+    eventId: string,
+    attributeIds: string[],
+  ): Promise<void> {
+    if (attributeIds.length === 0) {
+      return;
+    }
+    const existing = await tx.attributeOnEvent.findMany({
+      where: { eventId, attributeId: { in: attributeIds } },
+      select: { attributeId: true },
+    });
+    const linked = new Set(existing.map((link) => link.attributeId));
+    const toLink = attributeIds.filter((id) => !linked.has(id));
+    if (toLink.length === 0) {
+      return;
+    }
+    await tx.attributeOnEvent.createMany({
+      data: toLink.map((attributeId) => ({ eventId, attributeId })),
+      skipDuplicates: true,
+    });
   }
 
   async getBizUser(id: string, environmentId: string, include?: Prisma.BizUserInclude) {

--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -34,6 +34,7 @@ import {
   isNull,
   isValidISO8601,
 } from '@usertour/helpers';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 // Legacy data in DB may be stored as Record<string, boolean>; new shape is ColumnSetting[].
 // Normalize at the service boundary so callers always see the array shape.
@@ -62,7 +63,10 @@ function normalizeSegmentColumns(raw: unknown): ColumnSetting[] {
 export class BizService {
   private readonly logger = new Logger(BizService.name);
 
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly cache: ProjectCacheService,
+  ) {}
 
   async createBizUser(data: CreateBizInput) {
     return await this.prisma.bizUser.create({
@@ -672,6 +676,9 @@ export class BizService {
       externalCompanyId,
       attributes,
     );
+    if (!company) {
+      return null;
+    }
     await this.upsertBizMembership(tx, projectId, company.id, user.id, membership || {});
 
     return company;
@@ -796,6 +803,7 @@ export class BizService {
     attributes: Record<string, any>,
   ): Promise<Record<string, any>> {
     const insertAttribute = {};
+    let createdNewAttribute = false;
     for (const codeName in attributes) {
       const attrValue = attributes[codeName];
       const attrName = codeName;
@@ -821,6 +829,7 @@ export class BizService {
             bizType,
           },
         });
+        createdNewAttribute = true;
         if (newAttr) {
           // DateTime must be stored as ISO 8601 in UTC
           if (dataType === BizAttributeTypes.DateTime) {
@@ -857,6 +866,15 @@ export class BizService {
           );
         }
       }
+    }
+    // Defer cache invalidation to the request boundary. Doing this inline
+    // would fire BEFORE the surrounding $transaction commits, opening a
+    // window where another request could repopulate the cache from
+    // pre-commit DB state. ProjectCacheService falls back to immediate
+    // invalidation when called outside a request scope (i.e. when tx is
+    // actually `this.prisma` and statements auto-commit).
+    if (createdNewAttribute) {
+      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
     }
     return insertAttribute;
   }
@@ -902,42 +920,47 @@ export class BizService {
       attributes?: Record<string, any>;
     }>,
   ) {
-    return await this.prisma.$transaction(async (tx) => {
-      // First upsert the user with attributes
-      const user = await this.upsertBizUsers(tx, externalUserId, attributes || {}, environmentId);
+    // runInScope buffers any cache.invalidateDeferred calls made by
+    // insertBizAttributes (and friends) inside the $transaction, then
+    // fires them once the transaction has committed.
+    return await this.cache.runInScope(async () => {
+      return await this.prisma.$transaction(async (tx) => {
+        // First upsert the user with attributes
+        const user = await this.upsertBizUsers(tx, externalUserId, attributes || {}, environmentId);
 
-      if (!user) {
-        throw new UnknownError('Failed to upsert user');
-      }
-
-      // Handle companies/companies and memberships
-      if (companies) {
-        for (const company of companies) {
-          await this.upsertBizCompanies(
-            tx,
-            company.id,
-            externalUserId,
-            company.attributes || {},
-            environmentId,
-            {},
-          );
+        if (!user) {
+          throw new UnknownError('Failed to upsert user');
         }
-      }
 
-      if (memberships) {
-        for (const membership of memberships) {
-          await this.upsertBizCompanies(
-            tx,
-            membership.company.id,
-            externalUserId,
-            membership.company.attributes || {},
-            environmentId,
-            membership.attributes || {},
-          );
+        // Handle companies/companies and memberships
+        if (companies) {
+          for (const company of companies) {
+            await this.upsertBizCompanies(
+              tx,
+              company.id,
+              externalUserId,
+              company.attributes || {},
+              environmentId,
+              {},
+            );
+          }
         }
-      }
 
-      return user;
+        if (memberships) {
+          for (const membership of memberships) {
+            await this.upsertBizCompanies(
+              tx,
+              membership.company.id,
+              externalUserId,
+              membership.company.attributes || {},
+              environmentId,
+              membership.attributes || {},
+            );
+          }
+        }
+
+        return user;
+      });
     });
   }
 

--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -643,15 +643,13 @@ export class BizService {
       where: { externalId: String(externalUserId), environmentId },
     });
     if (!user) {
-      const created = await tx.bizUser.create({
+      return await tx.bizUser.create({
         data: {
           externalId: String(externalUserId),
           environmentId,
           data: insertAttribute,
         },
       });
-      this.cache.invalidateMemo(this.cache.memoKeys.bizUser(environmentId, String(externalUserId)));
-      return created;
     }
     const currentData = (user.data as Record<string, any>) || {};
     const insertData = filterNullAttributes({
@@ -664,7 +662,7 @@ export class BizService {
       return user;
     }
 
-    const updated = await tx.bizUser.update({
+    return await tx.bizUser.update({
       where: {
         id: user.id,
       },
@@ -672,13 +670,6 @@ export class BizService {
         data: insertData,
       },
     });
-    // Drop the per-request memo so subsequent findBizUser reads (e.g. the
-    // toggleContents condition evaluation that fires right after a
-    // bindToAttribute write) see the fresh `data`. Without this the memo
-    // would serve the scope-entry snapshot and segment rules filtering on
-    // the just-written attribute would evaluate against the old value.
-    this.cache.invalidateMemo(this.cache.memoKeys.bizUser(environmentId, String(externalUserId)));
-    return updated;
   }
 
   async upsertBizCompanies(
@@ -763,7 +754,7 @@ export class BizService {
         return company;
       }
 
-      const updated = await tx.bizCompany.update({
+      return await tx.bizCompany.update({
         where: {
           id: company.id,
         },
@@ -771,24 +762,15 @@ export class BizService {
           data: mergedData,
         },
       });
-      // Drop the per-request memo so subsequent reads see fresh `data`.
-      this.cache.invalidateMemo(
-        this.cache.memoKeys.bizCompany(environmentId, String(externalCompanyId)),
-      );
-      return updated;
     }
 
-    const created = await tx.bizCompany.create({
+    return await tx.bizCompany.create({
       data: {
         externalId: String(externalCompanyId),
         environmentId,
         data: insertAttribute,
       },
     });
-    this.cache.invalidateMemo(
-      this.cache.memoKeys.bizCompany(environmentId, String(externalCompanyId)),
-    );
-    return created;
   }
 
   async upsertBizMembership(
@@ -821,7 +803,7 @@ export class BizService {
         return relation;
       }
 
-      const updated = await tx.bizUserOnCompany.update({
+      return await tx.bizUserOnCompany.update({
         where: {
           id: relation.id,
         },
@@ -829,23 +811,14 @@ export class BizService {
           data: mergedData,
         },
       });
-      // Drop both membership memos: the bare `bizUserOnCompany:bizUser:bizCompany`
-      // key is targeted, and `bizUserOnCompanyWithBizCompany:bizUser:...` is wiped
-      // by user prefix because we don't carry envId/externalCompanyId here.
-      this.cache.invalidateMemo(this.cache.memoKeys.bizUserOnCompany(bizUserId, bizCompanyId));
-      this.cache.invalidateMemoByPrefix([`bizUserOnCompanyWithBizCompany:${bizUserId}:`]);
-      return updated;
     }
-    const created = await tx.bizUserOnCompany.create({
+    return await tx.bizUserOnCompany.create({
       data: {
         bizUserId,
         bizCompanyId,
         data: insertAttribute,
       },
     });
-    this.cache.invalidateMemo(this.cache.memoKeys.bizUserOnCompany(bizUserId, bizCompanyId));
-    this.cache.invalidateMemoByPrefix([`bizUserOnCompanyWithBizCompany:${bizUserId}:`]);
-    return created;
   }
 
   /**
@@ -1052,47 +1025,52 @@ export class BizService {
       attributes?: Record<string, any>;
     }>,
   ) {
-    // runInScope buffers any cache.invalidateDeferred calls made by
-    // insertBizAttributes (and friends) inside the $transaction, then
-    // fires them once the transaction has committed.
-    return await this.cache.runInScope(async () => {
-      return await this.prisma.$transaction(async (tx) => {
-        // First upsert the user with attributes
-        const user = await this.upsertBizUsers(tx, externalUserId, attributes || {}, environmentId);
+    // No runInScope wrap: the only cache write inside this $transaction is
+    // `invalidateDeferred(attrs(projectId))`, fired by insertBizAttributes
+    // when the SDK upsert payload introduces a previously-unseen attribute
+    // codeName. A mid-tx invalidate races with concurrent cross-pod readers
+    // that could fill the cache from pre-commit DB state — but the freshly
+    // created Attribute has no existing condition referencing it (admin
+    // couldn't have configured a rule against a codeName that didn't
+    // exist yet), so an `attrs` cache slice missing this row produces no
+    // observable effect on toggleContents output. The 5-minute TTL self-
+    // heals before any new admin-configured rule could reference it.
+    return await this.prisma.$transaction(async (tx) => {
+      // First upsert the user with attributes
+      const user = await this.upsertBizUsers(tx, externalUserId, attributes || {}, environmentId);
 
-        if (!user) {
-          throw new UnknownError('Failed to upsert user');
+      if (!user) {
+        throw new UnknownError('Failed to upsert user');
+      }
+
+      // Handle companies/companies and memberships
+      if (companies) {
+        for (const company of companies) {
+          await this.upsertBizCompanies(
+            tx,
+            company.id,
+            externalUserId,
+            company.attributes || {},
+            environmentId,
+            {},
+          );
         }
+      }
 
-        // Handle companies/companies and memberships
-        if (companies) {
-          for (const company of companies) {
-            await this.upsertBizCompanies(
-              tx,
-              company.id,
-              externalUserId,
-              company.attributes || {},
-              environmentId,
-              {},
-            );
-          }
+      if (memberships) {
+        for (const membership of memberships) {
+          await this.upsertBizCompanies(
+            tx,
+            membership.company.id,
+            externalUserId,
+            membership.company.attributes || {},
+            environmentId,
+            membership.attributes || {},
+          );
         }
+      }
 
-        if (memberships) {
-          for (const membership of memberships) {
-            await this.upsertBizCompanies(
-              tx,
-              membership.company.id,
-              externalUserId,
-              membership.company.attributes || {},
-              environmentId,
-              membership.attributes || {},
-            );
-          }
-        }
-
-        return user;
-      });
+      return user;
     });
   }
 

--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -839,7 +839,7 @@ export class BizService {
       attributes,
     );
     if (createdNewAttribute) {
-      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+      await this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
     }
     return outputData;
   }
@@ -854,7 +854,7 @@ export class BizService {
     projectId: string,
     eventId: string,
     attributes: Record<string, any>,
-  ): Promise<{ eventData: Record<string, any>; createdNewAttribute: boolean }> {
+  ): Promise<Record<string, any>> {
     const { outputData, attrMap, createdNewAttribute } = await this.resolveAttributes(
       tx,
       projectId,
@@ -871,9 +871,9 @@ export class BizService {
     await this.linkAttributesToEvent(tx, eventId, linkIds);
 
     if (createdNewAttribute) {
-      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
+      await this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
     }
-    return { eventData: outputData, createdNewAttribute };
+    return outputData;
   }
 
   /**

--- a/apps/server/src/content/content.module.ts
+++ b/apps/server/src/content/content.module.ts
@@ -1,6 +1,7 @@
 import { EnvironmentsModule } from '@/environments/environments.module';
 import { LocalizationsModule } from '@/localizations/localizations.module';
 import { ProjectsModule } from '@/projects/projects.module';
+import { SharedModule } from '@/shared/shared.module';
 import { Module } from '@nestjs/common';
 import { ContentGuard } from './content.guard';
 import { ContentResolver } from './content.resolver';
@@ -8,7 +9,7 @@ import { ContentService } from './content.service';
 import { WebSocketModule } from '@/web-socket/web-socket.module';
 
 @Module({
-  imports: [ProjectsModule, EnvironmentsModule, LocalizationsModule, WebSocketModule],
+  imports: [ProjectsModule, EnvironmentsModule, LocalizationsModule, WebSocketModule, SharedModule],
   providers: [ContentResolver, ContentService, ContentGuard],
   exports: [ContentService],
 })

--- a/apps/server/src/content/content.service.ts
+++ b/apps/server/src/content/content.service.ts
@@ -67,10 +67,21 @@ export class ContentService {
   }
 
   async updateContent(contentId: string, data: UpdateContentInput) {
-    return await this.prisma.content.update({
+    // A Content can be published into multiple environments via
+    // ContentOnEnvironment, so invalidating just `Content.environmentId`
+    // (the legacy primary field) leaves stale cache in every other env.
+    // The versionFull cache no longer embeds mutable Content fields
+    // (findVersions re-attaches Content from this slice on read), so a
+    // rename only needs to clear the env+type slices.
+    const envIds = await this.collectContentEnvIds(contentId);
+    const updated = await this.prisma.content.update({
       where: { id: contentId },
       data: { ...data } as any,
     });
+    if (envIds.length > 0) {
+      await this.cache.invalidate(envIds.flatMap((envId) => this.cache.envContentKeys(envId)));
+    }
+    return updated;
   }
 
   async addContentSteps(input: ContentStepsInput) {
@@ -420,19 +431,60 @@ export class ContentService {
   }
 
   async deleteContent(contentId: string) {
-    const updated = await this.prisma.content.update({
-      where: { id: contentId },
-      data: {
-        deleted: true,
-      },
+    // Same multi-environment caveat as updateContent: a Content can have
+    // ContentOnEnvironment rows in several envs, and each env has its
+    // own cached slice + pubver mapping that must be invalidated.
+    const envIds = await this.collectContentEnvIds(contentId);
+    const updated = await this.prisma.$transaction(async (tx) => {
+      // Drop per-env publication along with the soft-delete. Otherwise
+      // findPublishedVersionId (which only checks ContentOnEnvironment.
+      // published, not Content.deleted) would re-resolve a versionId for
+      // the deleted content the next time the cache repopulates.
+      await tx.contentOnEnvironment.deleteMany({ where: { contentId } });
+      return await tx.content.update({
+        where: { id: contentId },
+        data: { deleted: true },
+      });
     });
-    // The deleted Content drops out of the published-contents cache filter,
-    // and any cached publishedVersionId for it is now meaningless.
-    await this.cache.invalidate([
-      ...this.cache.envContentKeys(updated.environmentId),
-      this.cache.keys.publishedVersionId(updated.environmentId, contentId),
+    const keys = envIds.flatMap((envId) => [
+      ...this.cache.envContentKeys(envId),
+      this.cache.keys.publishedVersionId(envId, contentId),
     ]);
+    if (keys.length > 0) {
+      await this.cache.invalidate(keys);
+    }
+    // Mirror unpublishedContentVersion: cancel active sessions per env,
+    // not just the legacy primary one.
+    await Promise.all(
+      envIds.map((envId) => this.webSocketV2Gateway.cancelAllContentSessions(contentId, envId)),
+    );
     return updated;
+  }
+
+  /**
+   * All env ids that have this content cached. Pulls every COE row plus
+   * the legacy `Content.environmentId` (some old rows may have a primary
+   * env without a matching COE entry — defend in depth).
+   */
+  private async collectContentEnvIds(contentId: string): Promise<string[]> {
+    const [coes, content] = await Promise.all([
+      this.prisma.contentOnEnvironment.findMany({
+        where: { contentId },
+        select: { environmentId: true },
+      }),
+      this.prisma.content.findUnique({
+        where: { id: contentId },
+        select: { environmentId: true },
+      }),
+    ]);
+    const envIds = new Set<string>();
+    for (const coe of coes) {
+      envIds.add(coe.environmentId);
+    }
+    if (content?.environmentId) {
+      envIds.add(content.environmentId);
+    }
+    return [...envIds];
   }
 
   async duplicateContent(contentId: string, name: string, targetEnvironmentId?: string) {

--- a/apps/server/src/content/content.service.ts
+++ b/apps/server/src/content/content.service.ts
@@ -365,7 +365,10 @@ export class ContentService {
       return content;
     });
 
-    await this.cache.invalidate(this.cache.envContentKeys(environmentId));
+    await this.cache.invalidate([
+      ...this.cache.envContentKeys(environmentId),
+      this.cache.keys.publishedVersionId(environmentId, content.id),
+    ]);
 
     return content;
   }
@@ -405,7 +408,10 @@ export class ContentService {
       return content;
     });
 
-    await this.cache.invalidate(this.cache.envContentKeys(environmentId));
+    await this.cache.invalidate([
+      ...this.cache.envContentKeys(environmentId),
+      this.cache.keys.publishedVersionId(environmentId, contentId),
+    ]);
 
     // Cancel all active content sessions for this content
     await this.webSocketV2Gateway.cancelAllContentSessions(contentId, environmentId);
@@ -420,8 +426,12 @@ export class ContentService {
         deleted: true,
       },
     });
-    // The deleted Content drops out of the published-contents cache filter.
-    await this.cache.invalidate(this.cache.envContentKeys(updated.environmentId));
+    // The deleted Content drops out of the published-contents cache filter,
+    // and any cached publishedVersionId for it is now meaningless.
+    await this.cache.invalidate([
+      ...this.cache.envContentKeys(updated.environmentId),
+      this.cache.keys.publishedVersionId(updated.environmentId, contentId),
+    ]);
     return updated;
   }
 

--- a/apps/server/src/content/content.service.ts
+++ b/apps/server/src/content/content.service.ts
@@ -385,7 +385,7 @@ export class ContentService {
   }
 
   async unpublishedContentVersion(contentId: string, environmentId: string) {
-    const content = await this.prisma.$transaction(async (tx) => {
+    const result = await this.prisma.$transaction(async (tx) => {
       // Update Content table
       const content = await tx.content.update({
         where: { id: contentId },
@@ -416,18 +416,28 @@ export class ContentService {
         });
       }
 
-      return content;
+      return { content, unpublishedVersionId: contentOnEnv?.publishedVersionId ?? null };
     });
 
-    await this.cache.invalidate([
+    const keys = [
       ...this.cache.envContentKeys(environmentId),
       this.cache.keys.publishedVersionId(environmentId, contentId),
-    ]);
+    ];
+    // versionFull caches Version + Steps with a 30-min TTL on the assumption
+    // that a published version is immutable. Unpublishing breaks that
+    // invariant — once detached from every COE the version drops back into
+    // editable state, and any subsequent step / version edits would render
+    // a still-cached entry stale. Wipe it here so the next read repopulates
+    // from DB.
+    if (result.unpublishedVersionId) {
+      keys.push(this.cache.keys.versionFull(result.unpublishedVersionId));
+    }
+    await this.cache.invalidate(keys);
 
     // Cancel all active content sessions for this content
     await this.webSocketV2Gateway.cancelAllContentSessions(contentId, environmentId);
 
-    return content;
+    return result.content;
   }
 
   async deleteContent(contentId: string) {

--- a/apps/server/src/content/content.service.ts
+++ b/apps/server/src/content/content.service.ts
@@ -13,6 +13,7 @@ import { Prisma } from '@prisma/client';
 import { ParamsError, UnknownError } from '@/common/errors';
 import { ContentConfigObject } from '@usertour/types';
 import { duplicateConfig, duplicateData, duplicateStep } from '@usertour/helpers';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 @Injectable()
 export class ContentService {
@@ -20,6 +21,7 @@ export class ContentService {
     private prisma: PrismaService,
     private webSocketGateway: WebSocketGateway,
     private webSocketV2Gateway: WebSocketV2Gateway,
+    private readonly cache: ProjectCacheService,
   ) {}
 
   async createContent(input: ContentInput) {
@@ -363,6 +365,11 @@ export class ContentService {
       return content;
     });
 
+    // Cache must be invalidated BEFORE notifying SDK clients — otherwise an
+    // SDK that immediately re-EndBatches on the notification would still
+    // read the stale content list.
+    await this.cache.invalidate(this.cache.envContentKeys(environmentId));
+
     // Send WebSocket notification outside of transaction
     await this.webSocketGateway.notifyContentChanged(environmentId);
 
@@ -404,6 +411,9 @@ export class ContentService {
       return content;
     });
 
+    // Invalidate before notifying clients (see publishedContentVersion).
+    await this.cache.invalidate(this.cache.envContentKeys(environmentId));
+
     // send content change notification to all users in the environment
     await this.webSocketGateway.notifyContentChanged(environmentId);
 
@@ -414,12 +424,15 @@ export class ContentService {
   }
 
   async deleteContent(contentId: string) {
-    return await this.prisma.content.update({
+    const updated = await this.prisma.content.update({
       where: { id: contentId },
       data: {
         deleted: true,
       },
     });
+    // The deleted Content drops out of the published-contents cache filter.
+    await this.cache.invalidate(this.cache.envContentKeys(updated.environmentId));
+    return updated;
   }
 
   async duplicateContent(contentId: string, name: string, targetEnvironmentId?: string) {

--- a/apps/server/src/content/content.service.ts
+++ b/apps/server/src/content/content.service.ts
@@ -75,13 +75,14 @@ export class ContentService {
 
   async addContentSteps(input: ContentStepsInput) {
     const { contentId, versionId, steps, themeId } = input;
+    // Editable-only: matches addContentStep / updateContentStep /
+    // updateStepsSequence / updateContentVersion. The previous inline check
+    // duplicated the rule and was easy to drift out of sync.
+    await this.contentVersionIsEditable(versionId);
+    // Caller passes contentId explicitly — guard rail (versionId must belong
+    // to this content) since contentVersionIsEditable doesn't see contentId.
     const content = await this.getContent(contentId);
-    if (
-      !content ||
-      !content.editedVersionId ||
-      versionId !== content.editedVersionId ||
-      content.publishedVersionId === versionId
-    ) {
+    if (!content || content.editedVersionId !== versionId) {
       throw new ParamsError();
     }
 
@@ -126,13 +127,11 @@ export class ContentService {
 
   async addContentStep(data: CreateStepInput) {
     const versionId = data.versionId;
-    const version = await this.prisma.version.findUnique({
-      where: { id: versionId },
-    });
-    const content = await this.getContent(version.contentId);
-    if (!content || content.publishedVersionId === version.id) {
-      throw new ParamsError();
-    }
+    // Editable-only: must match content.editedVersionId AND not be currently
+    // published. Aligns with addContentSteps / updateStepsSequence /
+    // updateContentVersion (the previous guard let historical published
+    // versions through, breaking the published-immutability contract).
+    await this.contentVersionIsEditable(versionId);
 
     try {
       return await this.prisma.$transaction(async (tx) => {
@@ -174,10 +173,11 @@ export class ContentService {
 
   async updateContentStep(stepId: string, data: UpdateStepInput) {
     const version = await this.prisma.step.findUnique({ where: { id: stepId } }).version();
-    const content = await this.getContent(version.contentId);
-    if (!content || content.publishedVersionId === version.id) {
+    if (!version) {
       throw new ParamsError();
     }
+    // Editable-only: see addContentStep.
+    await this.contentVersionIsEditable(version.id);
     return await this.prisma.step.update({
       where: { id: stepId },
       data,
@@ -365,13 +365,7 @@ export class ContentService {
       return content;
     });
 
-    // Cache must be invalidated BEFORE notifying SDK clients — otherwise an
-    // SDK that immediately re-EndBatches on the notification would still
-    // read the stale content list.
     await this.cache.invalidate(this.cache.envContentKeys(environmentId));
-
-    // Send WebSocket notification outside of transaction
-    await this.webSocketGateway.notifyContentChanged(environmentId);
 
     return content;
   }
@@ -411,11 +405,7 @@ export class ContentService {
       return content;
     });
 
-    // Invalidate before notifying clients (see publishedContentVersion).
     await this.cache.invalidate(this.cache.envContentKeys(environmentId));
-
-    // send content change notification to all users in the environment
-    await this.webSocketGateway.notifyContentChanged(environmentId);
 
     // Cancel all active content sessions for this content
     await this.webSocketV2Gateway.cancelAllContentSessions(contentId, environmentId);

--- a/apps/server/src/environments/environments.module.ts
+++ b/apps/server/src/environments/environments.module.ts
@@ -1,11 +1,12 @@
 import { ProjectsModule } from '@/projects/projects.module';
+import { SharedModule } from '@/shared/shared.module';
 import { Module } from '@nestjs/common';
 import { EnvironmentsGuard } from './environments.guard';
 import { EnvironmentsResolver } from './environments.resolver';
 import { EnvironmentsService } from './environments.service';
 
 @Module({
-  imports: [ProjectsModule],
+  imports: [ProjectsModule, SharedModule],
   providers: [EnvironmentsResolver, EnvironmentsService, EnvironmentsGuard],
   exports: [EnvironmentsService],
 })

--- a/apps/server/src/environments/environments.service.ts
+++ b/apps/server/src/environments/environments.service.ts
@@ -7,10 +7,14 @@ import {
   PrimaryEnvironmentCannotBeDeletedError,
 } from '@/common/errors';
 import { CreateAccessTokenInput } from './dto/access-token.dto';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 @Injectable()
 export class EnvironmentsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly cache: ProjectCacheService,
+  ) {}
 
   async create(newData: CreateEnvironmentInput) {
     return await this.prisma.$transaction(async (tx) => {
@@ -79,7 +83,16 @@ export class EnvironmentsService {
   }
 
   async delete(id: string) {
-    return await this.prisma.$transaction(async (tx) => {
+    // Fetch contentIds before the tx so we can sweep per-content pubver
+    // cache keys after the COE rows are gone — same shape as deleteContent.
+    const coeContentIds = (
+      await this.prisma.contentOnEnvironment.findMany({
+        where: { environmentId: id },
+        select: { contentId: true },
+      })
+    ).map((c) => c.contentId);
+
+    const updated = await this.prisma.$transaction(async (tx) => {
       // Get the environment to find its projectId
       const environment = await tx.environment.findUnique({
         where: { id },
@@ -106,13 +119,7 @@ export class EnvironmentsService {
         throw new LastEnvironmentCannotBeDeletedError();
       }
 
-      // Check if there are any ContentOnEnvironment records
-      const contentCount = await tx.contentOnEnvironment.count({
-        where: { environmentId: id },
-      });
-
-      // Only delete ContentOnEnvironment records if they exist
-      if (contentCount > 0) {
+      if (coeContentIds.length > 0) {
         await tx.contentOnEnvironment.deleteMany({
           where: { environmentId: id },
         });
@@ -124,6 +131,18 @@ export class EnvironmentsService {
         data: { deleted: true },
       });
     });
+
+    // Invalidate every cache slice keyed by this env: the per-type Content
+    // slice and the per-content publishedVersionId mapping. Otherwise an
+    // SDK still authenticated against this env's token would keep serving
+    // its (now-orphaned) content for up to PROJECT_CONFIG_TTL_SECONDS.
+    const keys = [
+      ...this.cache.envContentKeys(id),
+      ...coeContentIds.map((cid) => this.cache.keys.publishedVersionId(id, cid)),
+    ];
+    await this.cache.invalidate(keys);
+
+    return updated;
   }
 
   async get(id: string) {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,7 +1,8 @@
-import { ValidationPipe } from '@nestjs/common';
+import { Logger as NestLogger, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { PrismaService } from 'nestjs-prisma';
 import { RedisIoAdapter } from './adapters/redis-io.adapter';
 import { AppModule } from './app.module';
 import { Logger } from 'nestjs-pino';
@@ -25,6 +26,20 @@ async function bootstrap() {
 
   // Use pino logger
   app.useLogger(app.get(Logger));
+
+  // Engine-level Prisma SQL logging (catches SQL inside $transaction(callback),
+  // which middleware cannot see). Gated by the same env var as the middleware.
+  if (process.env.ENABLE_PRISMA_LOGGING === 'true') {
+    const prisma = app.get(PrismaService);
+    const sqlLogger = new NestLogger('PrismaSQL');
+    type QueryEvent = { query: string; params: string; duration: number; target: string };
+    (prisma as unknown as { $on: (event: 'query', cb: (e: QueryEvent) => void) => void }).$on(
+      'query',
+      (e) => {
+        sqlLogger.log(`took ${e.duration}ms ${e.query} ${e.params}`);
+      },
+    );
+  }
 
   // Catch all exceptions
   // app.useGlobalFilters(new AllExceptionsFilter());

--- a/apps/server/src/projects/projects.module.ts
+++ b/apps/server/src/projects/projects.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ProjectsResolver } from './projects.resolver';
 import { ProjectsService } from './projects.service';
 import { LicenseModule } from '@/license/license.module';
+import { SharedModule } from '@/shared/shared.module';
 
 @Module({
-  imports: [LicenseModule],
+  imports: [LicenseModule, SharedModule],
   providers: [ProjectsResolver, ProjectsService],
   exports: [ProjectsService],
 })

--- a/apps/server/src/projects/projects.service.ts
+++ b/apps/server/src/projects/projects.service.ts
@@ -137,7 +137,7 @@ export class ProjectsService {
     // Memoized per request scope: a single EndBatch builds one session per
     // active content type and each session call hits this method once,
     // producing 3+ identical Project + Subscription lookups otherwise.
-    return this.cache.memoize('projectConfig', projectId, () => {
+    return this.cache.memoize(this.cache.memoKeys.projectConfig(projectId), () => {
       const isSelfHostedMode = this.configService.get('globalConfig.isSelfHostedMode');
       if (isSelfHostedMode) {
         return this.getSelfHostedConfig(projectId);

--- a/apps/server/src/projects/projects.service.ts
+++ b/apps/server/src/projects/projects.service.ts
@@ -9,6 +9,7 @@ import {
   LicenseDecodeError,
 } from '@/common/errors';
 import { LicenseService } from '@/license/license.service';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 import { Environment } from '@/common/types/schema';
 import { ProjectConfig } from '@usertour/types';
 
@@ -20,6 +21,7 @@ export class ProjectsService {
     private prisma: PrismaService,
     private licenseService: LicenseService,
     private configService: ConfigService,
+    private cache: ProjectCacheService,
   ) {}
 
   async getUserProject(userId: string, projectId: string) {
@@ -132,13 +134,16 @@ export class ProjectsService {
   }
 
   async getProjectConfig(projectId: string): Promise<ProjectConfig> {
-    const isSelfHostedMode = this.configService.get('globalConfig.isSelfHostedMode');
-
-    if (isSelfHostedMode) {
-      return await this.getSelfHostedConfig(projectId);
-    }
-
-    return await this.getCloudConfig(projectId);
+    // Memoized per request scope: a single EndBatch builds one session per
+    // active content type and each session call hits this method once,
+    // producing 3+ identical Project + Subscription lookups otherwise.
+    return this.cache.memoize('projectConfig', projectId, () => {
+      const isSelfHostedMode = this.configService.get('globalConfig.isSelfHostedMode');
+      if (isSelfHostedMode) {
+        return this.getSelfHostedConfig(projectId);
+      }
+      return this.getCloudConfig(projectId);
+    });
   }
 
   /**

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -51,8 +51,9 @@ export class ProjectCacheService {
   constructor(private readonly redis: RedisService) {}
 
   /**
-   * Cache key builders. All keys are prefixed by their scope (project / env / etc.)
-   * so an `invalidateProject(id)` style sweep can be implemented without scanning.
+   * Redis cache key builders. All keys are prefixed by their scope
+   * (project / env / etc.) so an `invalidateProject(id)` style sweep can be
+   * implemented without scanning. Consumed by `get` / `mget` / `invalidate`.
    */
   readonly keys = {
     /** All project-level Attribute definitions for content evaluation. */
@@ -70,6 +71,28 @@ export class ProjectCacheService {
       `env:${envId}:content:${contentId}:pubver`,
     /** Project + Subscription bundle used by the license check. */
     projectLicense: (projectId: string) => `proj:${projectId}:license`,
+  };
+
+  /**
+   * Per-request memo key builders. Consumed by `memoize`. Each entry's
+   * leading segment doubles as the namespace, so distinct entity types
+   * can never collide in `RequestContext.memo`. Centralized so callers
+   * across files share a single source of truth — e.g. `hasBizEvent` is
+   * issued from both `ContentDataService` and `ConditionEvaluationService`,
+   * and both must produce the same key for the memo to coalesce them.
+   *
+   * Array inputs are sorted before joining so the same set in different
+   * orders hits the same memo entry.
+   */
+  readonly memoKeys = {
+    bizUser: (envId: string, externalUserId: string) => `bizUser:${envId}:${externalUserId}`,
+    bizCompany: (envId: string, externalCompanyId: string) =>
+      `bizCompany:${envId}:${externalCompanyId}`,
+    bizUserOnCompany: (bizUserId: string, bizCompanyId: string) =>
+      `bizUserOnCompany:${bizUserId}:${bizCompanyId}`,
+    bizUserOnCompanyWithBizCompany: (bizUserId: string, envId: string, externalCompanyId: string) =>
+      `bizUserOnCompanyWithBizCompany:${bizUserId}:${envId}:${externalCompanyId}`,
+    projectConfig: (projectId: string) => `projectConfig:${projectId}`,
   };
 
   /**
@@ -216,15 +239,15 @@ export class ProjectCacheService {
    * Per-request lookup memo. Coalesces same-scope repeated reads (the 6-type
    * toggleContents loop, findThemes, session-builder, segment evaluation
    * all hitting the same BizUser / BizCompany / config) down to one DB hit
-   * per (namespace, key) pair. Lifetime is bound to the current `runInScope`
-   * boundary; outside a scope it falls through to the loader.
+   * per `key`. Lifetime is bound to the current `runInScope` boundary;
+   * outside a scope it falls through to the loader.
    *
    * Stores the in-flight Promise so concurrent callers don't race two
    * queries before the first one resolves.
    *
-   * `namespace` partitions keys so distinct entity types (`bizUser`,
-   * `bizCompany`, `projectConfig`, …) can't collide when their identifiers
-   * happen to share a shape. Pick a stable, lowercased entity name.
+   * Always pass keys built via `memoKeys.*` so distinct entity types stay
+   * partitioned and cross-file callers (e.g. the two `hasBizEvent` sites)
+   * coalesce into one memo entry.
    *
    * Caveat: holds whatever entity the first caller resolved. Mid-scope
    * writes (e.g. `updateUserSeenAttributes` bumping lastSeenAt) are not
@@ -232,18 +255,17 @@ export class ProjectCacheService {
    * "scope-entry snapshot" semantics for evaluation. Paths that need
    * freshness across an in-scope write must bypass this method.
    */
-  async memoize<T>(namespace: string, key: string, loader: () => Promise<T>): Promise<T> {
+  async memoize<T>(key: string, loader: () => Promise<T>): Promise<T> {
     const ctx = requestContext.getStore();
     if (!ctx) {
       return loader();
     }
-    const fullKey = `${namespace}:${key}`;
-    const existing = ctx.memo.get(fullKey);
+    const existing = ctx.memo.get(key);
     if (existing) {
       return existing as Promise<T>;
     }
     const promise = loader();
-    ctx.memo.set(fullKey, promise);
+    ctx.memo.set(key, promise);
     return promise;
   }
 

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { RedisService } from './redis.service';
+import { createRequestContext, requestContext } from './request-context';
 
 /**
  * Centralized cache for project-scoped configuration data that the SDK
@@ -15,6 +16,32 @@ import { RedisService } from './redis.service';
  * Values must JSON round-trip cleanly. Prisma entities with Date columns
  * will lose their `Date` type — callers should either project the entity
  * down to a primitive shape or revive Date fields explicitly on read.
+ *
+ * --- Invalidation model ---
+ *
+ * Writes call `invalidateDeferred(key)` which buffers the invalidation in
+ * the current request's AsyncLocalStorage context (set up by `runInScope`
+ * at message handler entry). Buffered invalidations fire the next time
+ * the cache is READ via `getOrFetch` in the same scope, or when the scope
+ * ends — whichever comes first. This guarantees:
+ *   - same-request reads after a write see the new state
+ *   - concurrent cross-request reads can't repopulate cache from
+ *     pre-commit DB state, because the write tx has always committed
+ *     by the time the deferred invalidation fires
+ *
+ * --- IMPORTANT constraint ---
+ *
+ * Do NOT call `getOrFetch` from inside an open `prisma.$transaction(callback)`
+ * block. The pre-read flush would invalidate cache while the surrounding tx
+ * has not yet committed, allowing a concurrent reader to query the DB
+ * (READ COMMITTED hides the in-flight tx) and repopulate the cache with
+ * stale data. The deferred-write protection assumes reads happen AFTER any
+ * write tx that touched the same key has committed.
+ *
+ * Today no caller violates this — `getOrFetch` is only invoked from the
+ * EndBatch / toggleContents path which runs auto-commit Prisma calls, not
+ * inside a wrapping $transaction. New cache call sites should preserve
+ * this invariant or pre-fetch the cached values before opening the tx.
  */
 @Injectable()
 export class ProjectCacheService {
@@ -48,11 +75,19 @@ export class ProjectCacheService {
    * Read-through cache. Returns the cached value when present, otherwise
    * runs the loader and writes the result back with the given TTL.
    *
+   * Drains any pending `invalidateDeferred` calls from the current request
+   * scope BEFORE reading. Without this, a single message handler that
+   * (a) creates a new entity, (b) defers invalidation, then (c) reads the
+   * cached set in the same scope (e.g. trackEvent → toggleContents) would
+   * see its own pre-invalidation snapshot.
+   *
    * Negative results (loader returning null/undefined) are NOT cached —
    * we don't want to lock in a "not found" answer for 5 minutes if the
    * row was just about to be created.
    */
   async getOrFetch<T>(key: string, ttlSeconds: number, loader: () => Promise<T>): Promise<T> {
+    await this.flushDeferred();
+
     const cached = await this.redis.getJson<T>(key);
     if (cached !== null) return cached;
 
@@ -76,6 +111,64 @@ export class ProjectCacheService {
       // expire the stale entry. Log so it shows up in monitoring.
       this.logger.error(`Failed to invalidate cache keys ${JSON.stringify(keys)}: ${err}`);
     }
+  }
+
+  /**
+   * Defer cache invalidation until the current request scope ends.
+   *
+   * Called from inside domain methods that may run within a $transaction —
+   * invalidating mid-tx would race with concurrent reads still seeing the
+   * pre-commit DB state. By deferring to the request boundary we guarantee
+   * the invalidation fires after every embedded $transaction has committed.
+   *
+   * If no request scope is active we fall back to immediate invalidation.
+   * That's correct for callers that aren't inside a transaction (their
+   * Prisma writes auto-commit per statement).
+   */
+  invalidateDeferred(keys: string | string[]): void {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      void this.invalidate(keys);
+      return;
+    }
+    const list = Array.isArray(keys) ? keys : [keys];
+    for (const key of list) {
+      ctx.deferredCacheInvalidations.add(key);
+    }
+  }
+
+  /**
+   * Establish a request scope around `fn`. Any `invalidateDeferred` calls
+   * inside the scope are buffered and fired the next time the cache is
+   * read (via `getOrFetch`) or once `fn` resolves — whichever comes first.
+   *
+   * Use this at outer boundaries that own a transaction lifecycle but aren't
+   * already running inside another scope (admin mutations, etc.). Websocket
+   * message handlers wrap dispatch with this same primitive.
+   */
+  async runInScope<T>(fn: () => Promise<T>): Promise<T> {
+    const ctx = createRequestContext();
+    try {
+      return await requestContext.run(ctx, fn);
+    } finally {
+      // Tail flush: covers requests that mutate but never read.
+      if (ctx.deferredCacheInvalidations.size > 0) {
+        await this.invalidate([...ctx.deferredCacheInvalidations]);
+      }
+    }
+  }
+
+  /**
+   * Drain any pending `invalidateDeferred` calls in the current request
+   * scope. Called automatically by `getOrFetch` before each cache read.
+   * Safe to call when no scope is active (no-op).
+   */
+  private async flushDeferred(): Promise<void> {
+    const ctx = requestContext.getStore();
+    if (!ctx || ctx.deferredCacheInvalidations.size === 0) return;
+    const keys = [...ctx.deferredCacheInvalidations];
+    ctx.deferredCacheInvalidations.clear();
+    await this.invalidate(keys);
   }
 
   /** One-shot wipe of every project-scoped key for a given project. */

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -147,14 +147,17 @@ export class ProjectCacheService {
    * pre-commit DB state. By deferring to the request boundary we guarantee
    * the invalidation fires after every embedded $transaction has committed.
    *
-   * If no request scope is active we fall back to immediate invalidation.
-   * That's correct for callers that aren't inside a transaction (their
-   * Prisma writes auto-commit per statement).
+   * If no request scope is active we fall back to immediate invalidation
+   * and `await` the underlying Redis DEL so callers that wish to gate
+   * their response on cache consistency (e.g. an admin GraphQL mutation
+   * that returns before the next SDK read) can `await` this call.
+   * In-scope callers can still ignore the returned Promise — the buffer
+   * write is synchronous and the returned Promise resolves immediately.
    */
-  invalidateDeferred(keys: string | string[]): void {
+  async invalidateDeferred(keys: string | string[]): Promise<void> {
     const ctx = requestContext.getStore();
     if (!ctx) {
-      void this.invalidate(keys);
+      await this.invalidate(keys);
       return;
     }
     const list = Array.isArray(keys) ? keys : [keys];

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -23,7 +23,7 @@ import { createRequestContext, requestContext } from './request-context';
  * Writes call `invalidateDeferred(key)` which buffers the invalidation in
  * the current request's AsyncLocalStorage context (set up by `runInScope`
  * at message handler entry). Buffered invalidations fire the next time
- * the cache is READ via `getOrFetch` in the same scope, or when the scope
+ * the cache is READ via `get` in the same scope, or when the scope
  * ends — whichever comes first. This guarantees:
  *   - same-request reads after a write see the new state
  *   - concurrent cross-request reads can't repopulate cache from
@@ -32,14 +32,14 @@ import { createRequestContext, requestContext } from './request-context';
  *
  * --- IMPORTANT constraint ---
  *
- * Do NOT call `getOrFetch` from inside an open `prisma.$transaction(callback)`
+ * Do NOT call `get` from inside an open `prisma.$transaction(callback)`
  * block. The pre-read flush would invalidate cache while the surrounding tx
  * has not yet committed, allowing a concurrent reader to query the DB
  * (READ COMMITTED hides the in-flight tx) and repopulate the cache with
  * stale data. The deferred-write protection assumes reads happen AFTER any
  * write tx that touched the same key has committed.
  *
- * Today no caller violates this — `getOrFetch` is only invoked from the
+ * Today no caller violates this — `get` is only invoked from the
  * EndBatch / toggleContents path which runs auto-commit Prisma calls, not
  * inside a wrapping $transaction. New cache call sites should preserve
  * this invariant or pre-fetch the cached values before opening the tx.
@@ -86,7 +86,7 @@ export class ProjectCacheService {
    * we don't want to lock in a "not found" answer for 5 minutes if the
    * row was just about to be created.
    */
-  async getOrFetch<T>(key: string, ttlSeconds: number, loader: () => Promise<T>): Promise<T> {
+  async get<T>(key: string, ttlSeconds: number, loader: () => Promise<T>): Promise<T> {
     await this.flushDeferred();
 
     const cached = await this.redis.getJson<T>(key);
@@ -139,9 +139,58 @@ export class ProjectCacheService {
   }
 
   /**
+   * Batch variant of `get`: read N keys with one MGET, batch-load the
+   * misses via the caller-provided loader (typically a single `findMany`),
+   * then write the freshly-loaded entries back with one pipelined MSETEX.
+   *
+   * Returns a Map keyed by the input cache key. Order of `keys` is preserved
+   * via the returned Map insertion order, but callers should look up by key
+   * rather than relying on iteration order.
+   */
+  async mget<T>(
+    keys: string[],
+    ttlSeconds: number,
+    loadMissing: (missingKeys: string[]) => Promise<Map<string, T>>,
+  ): Promise<Map<string, T>> {
+    await this.flushDeferred();
+
+    const result = new Map<string, T>();
+    if (keys.length === 0) return result;
+
+    const cached = await this.redis.mgetJson<T>(keys);
+    const missingKeys: string[] = [];
+    for (let i = 0; i < keys.length; i++) {
+      const v = cached[i];
+      if (v !== null) {
+        result.set(keys[i], v);
+      } else {
+        missingKeys.push(keys[i]);
+      }
+    }
+
+    if (missingKeys.length > 0) {
+      const fresh = await loadMissing(missingKeys);
+      const toCache: Array<[string, T]> = [];
+      for (const [key, value] of fresh) {
+        result.set(key, value);
+        toCache.push([key, value]);
+      }
+      if (toCache.length > 0) {
+        try {
+          await this.redis.setJsonExMany(toCache, ttlSeconds);
+        } catch (err) {
+          this.logger.warn(`Failed to write ${toCache.length} cache entries: ${err}`);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Establish a request scope around `fn`. Any `invalidateDeferred` calls
    * inside the scope are buffered and fired the next time the cache is
-   * read (via `getOrFetch`) or once `fn` resolves — whichever comes first.
+   * read (via `get`) or once `fn` resolves — whichever comes first.
    *
    * Use this at outer boundaries that own a transaction lifecycle but aren't
    * already running inside another scope (admin mutations, etc.). Websocket
@@ -161,7 +210,7 @@ export class ProjectCacheService {
 
   /**
    * Drain any pending `invalidateDeferred` calls in the current request
-   * scope. Called automatically by `getOrFetch` before each cache read.
+   * scope. Called automatically by `get` before each cache read.
    * Safe to call when no scope is active (no-op).
    */
   private async flushDeferred(): Promise<void> {

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type { BizUser } from '@prisma/client';
 import { ContentDataType } from '@usertour/types';
 import { RedisService } from './redis.service';
 import { createRequestContext, requestContext } from './request-context';
@@ -210,6 +211,43 @@ export class ProjectCacheService {
         await this.invalidate([...ctx.deferredCacheInvalidations]);
       }
     }
+  }
+
+  /**
+   * Per-request memo for BizUser lookups by `(envId, externalUserId)`.
+   *
+   * Coalesces the 17+ findFirst calls that one EndBatch fans out to (6-type
+   * toggleContents loop, findThemes, session-builder, segment evaluation)
+   * down to one DB hit. The memo lifetime is bound to the current
+   * `runInScope` boundary: outside a scope it falls through to the loader.
+   *
+   * Stores the in-flight Promise so concurrent callers don't race two
+   * findFirst queries before the first one resolves.
+   *
+   * Caveat: holds whatever entity the first caller resolved. EndBatch may
+   * write `bizUser.data` mid-scope (`updateUserSeenAttributes` updates
+   * lastSeenAt), and subsequent memo reads return the pre-write snapshot.
+   * That matches the desired semantics — segment / condition evaluation
+   * uses a consistent "scope-entry snapshot" of the user. Paths that need
+   * freshness across an in-scope write must bypass this method.
+   */
+  async memoizeBizUser(
+    envId: string,
+    externalUserId: string,
+    loader: () => Promise<BizUser | null>,
+  ): Promise<BizUser | null> {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      return loader();
+    }
+    const key = `${envId}:${externalUserId}`;
+    const existing = ctx.bizUserMemo.get(key);
+    if (existing) {
+      return existing;
+    }
+    const promise = loader();
+    ctx.bizUserMemo.set(key, promise);
+    return promise;
   }
 
   /**

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -273,6 +273,41 @@ export class ProjectCacheService {
   }
 
   /**
+   * Drop one memo entry from the current request scope. Used by writers
+   * that mutate the cached entity mid-scope (e.g. `bindToAttribute` writes
+   * a user-defined field on `BizUser.data` inside a trackEvent tx) so the
+   * next read repopulates from DB instead of returning the pre-write
+   * snapshot. No-op outside a scope.
+   */
+  invalidateMemo(key: string): void {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      return;
+    }
+    ctx.memo.delete(key);
+  }
+
+  /**
+   * Drop every memo entry whose key starts with one of `prefixes`. Used
+   * when the writer doesn't carry the full key parameters — e.g.
+   * `upsertBizMembership` knows `bizUserId` and `bizCompanyId` but not the
+   * `(envId, externalCompanyId)` tuple stored in the
+   * `bizUserOnCompanyWithBizCompany` key. Wiping by user prefix is safe
+   * because each request scope only holds memos for that request's user.
+   */
+  invalidateMemoByPrefix(prefixes: string[]): void {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      return;
+    }
+    for (const key of [...ctx.memo.keys()]) {
+      if (prefixes.some((p) => key.startsWith(p))) {
+        ctx.memo.delete(key);
+      }
+    }
+  }
+
+  /**
    * Drain any pending `invalidateDeferred` calls in the current request
    * scope. Called automatically by `get` before each cache read.
    * Safe to call when no scope is active (no-op).

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { BizUser } from '@prisma/client';
 import { ContentDataType } from '@usertour/types';
 import { RedisService } from './redis.service';
 import { createRequestContext, requestContext } from './request-context';
@@ -214,39 +213,37 @@ export class ProjectCacheService {
   }
 
   /**
-   * Per-request memo for BizUser lookups by `(envId, externalUserId)`.
-   *
-   * Coalesces the 17+ findFirst calls that one EndBatch fans out to (6-type
-   * toggleContents loop, findThemes, session-builder, segment evaluation)
-   * down to one DB hit. The memo lifetime is bound to the current
-   * `runInScope` boundary: outside a scope it falls through to the loader.
+   * Per-request lookup memo. Coalesces same-scope repeated reads (the 6-type
+   * toggleContents loop, findThemes, session-builder, segment evaluation
+   * all hitting the same BizUser / BizCompany / config) down to one DB hit
+   * per (namespace, key) pair. Lifetime is bound to the current `runInScope`
+   * boundary; outside a scope it falls through to the loader.
    *
    * Stores the in-flight Promise so concurrent callers don't race two
-   * findFirst queries before the first one resolves.
+   * queries before the first one resolves.
    *
-   * Caveat: holds whatever entity the first caller resolved. EndBatch may
-   * write `bizUser.data` mid-scope (`updateUserSeenAttributes` updates
-   * lastSeenAt), and subsequent memo reads return the pre-write snapshot.
-   * That matches the desired semantics — segment / condition evaluation
-   * uses a consistent "scope-entry snapshot" of the user. Paths that need
+   * `namespace` partitions keys so distinct entity types (`bizUser`,
+   * `bizCompany`, `projectConfig`, …) can't collide when their identifiers
+   * happen to share a shape. Pick a stable, lowercased entity name.
+   *
+   * Caveat: holds whatever entity the first caller resolved. Mid-scope
+   * writes (e.g. `updateUserSeenAttributes` bumping lastSeenAt) are not
+   * reflected in subsequent memo reads — that matches the desired
+   * "scope-entry snapshot" semantics for evaluation. Paths that need
    * freshness across an in-scope write must bypass this method.
    */
-  async memoizeBizUser(
-    envId: string,
-    externalUserId: string,
-    loader: () => Promise<BizUser | null>,
-  ): Promise<BizUser | null> {
+  async memoize<T>(namespace: string, key: string, loader: () => Promise<T>): Promise<T> {
     const ctx = requestContext.getStore();
     if (!ctx) {
       return loader();
     }
-    const key = `${envId}:${externalUserId}`;
-    const existing = ctx.bizUserMemo.get(key);
+    const fullKey = `${namespace}:${key}`;
+    const existing = ctx.memo.get(fullKey);
     if (existing) {
-      return existing;
+      return existing as Promise<T>;
     }
     const promise = loader();
-    ctx.bizUserMemo.set(key, promise);
+    ctx.memo.set(fullKey, promise);
     return promise;
   }
 

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+/**
+ * Centralized cache for project-scoped configuration data that the SDK
+ * websocket message handlers read on every toggleContents iteration but
+ * which only changes when an admin updates the configuration. The single
+ * source of truth for cache key naming + TTL lives here so read sites and
+ * write-side invalidation never drift apart.
+ *
+ * Multi-instance safe: backed only by Redis, no in-process memory layer.
+ * Adding a memory layer would require Redis pub/sub for cross-Pod
+ * invalidation; the latency win is not worth the complexity until measured.
+ *
+ * Values must JSON round-trip cleanly. Prisma entities with Date columns
+ * will lose their `Date` type — callers should either project the entity
+ * down to a primitive shape or revive Date fields explicitly on read.
+ */
+@Injectable()
+export class ProjectCacheService {
+  private readonly logger = new Logger(ProjectCacheService.name);
+
+  constructor(private readonly redis: RedisService) {}
+
+  /**
+   * Cache key builders. All keys are prefixed by their scope (project / env / etc.)
+   * so an `invalidateProject(id)` style sweep can be implemented without scanning.
+   */
+  readonly keys = {
+    /** All project-level Attribute definitions for content evaluation. */
+    attrs: (projectId: string) => `proj:${projectId}:attrs`,
+    /** All Themes for a project. */
+    themes: (projectId: string) => `proj:${projectId}:themes`,
+    /** Published Content rows for an environment, sliced by content type. */
+    contents: (envId: string, type: string) => `env:${envId}:contents:${type}`,
+    /** Full Version row including steps for a specific version id. */
+    versionFull: (versionId: string) => `version:${versionId}:full`,
+    /** Single Segment definition by id. */
+    segment: (segmentId: string) => `segment:${segmentId}`,
+    /** Map a (env, content) → publishedVersionId so the join doesn't re-run. */
+    publishedVersionId: (envId: string, contentId: string) =>
+      `env:${envId}:content:${contentId}:pubver`,
+    /** Project + Subscription bundle used by the license check. */
+    projectLicense: (projectId: string) => `proj:${projectId}:license`,
+  };
+
+  /**
+   * Read-through cache. Returns the cached value when present, otherwise
+   * runs the loader and writes the result back with the given TTL.
+   *
+   * Negative results (loader returning null/undefined) are NOT cached —
+   * we don't want to lock in a "not found" answer for 5 minutes if the
+   * row was just about to be created.
+   */
+  async getOrFetch<T>(key: string, ttlSeconds: number, loader: () => Promise<T>): Promise<T> {
+    const cached = await this.redis.getJson<T>(key);
+    if (cached !== null) return cached;
+
+    const fresh = await loader();
+    if (fresh !== undefined && fresh !== null) {
+      try {
+        await this.redis.setJsonEx(key, fresh, ttlSeconds);
+      } catch (err) {
+        // Cache write failure must not break the read path.
+        this.logger.warn(`Failed to write cache for ${key}: ${err}`);
+      }
+    }
+    return fresh;
+  }
+
+  async invalidate(keys: string | string[]): Promise<void> {
+    try {
+      await this.redis.del(keys);
+    } catch (err) {
+      // Invalidation failure is bad but not fatal — TTL will eventually
+      // expire the stale entry. Log so it shows up in monitoring.
+      this.logger.error(`Failed to invalidate cache keys ${JSON.stringify(keys)}: ${err}`);
+    }
+  }
+
+  /** One-shot wipe of every project-scoped key for a given project. */
+  async invalidateProject(projectId: string): Promise<void> {
+    await this.invalidate([
+      this.keys.attrs(projectId),
+      this.keys.themes(projectId),
+      this.keys.projectLicense(projectId),
+    ]);
+  }
+}

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -273,41 +273,6 @@ export class ProjectCacheService {
   }
 
   /**
-   * Drop one memo entry from the current request scope. Used by writers
-   * that mutate the cached entity mid-scope (e.g. `bindToAttribute` writes
-   * a user-defined field on `BizUser.data` inside a trackEvent tx) so the
-   * next read repopulates from DB instead of returning the pre-write
-   * snapshot. No-op outside a scope.
-   */
-  invalidateMemo(key: string): void {
-    const ctx = requestContext.getStore();
-    if (!ctx) {
-      return;
-    }
-    ctx.memo.delete(key);
-  }
-
-  /**
-   * Drop every memo entry whose key starts with one of `prefixes`. Used
-   * when the writer doesn't carry the full key parameters — e.g.
-   * `upsertBizMembership` knows `bizUserId` and `bizCompanyId` but not the
-   * `(envId, externalCompanyId)` tuple stored in the
-   * `bizUserOnCompanyWithBizCompany` key. Wiping by user prefix is safe
-   * because each request scope only holds memos for that request's user.
-   */
-  invalidateMemoByPrefix(prefixes: string[]): void {
-    const ctx = requestContext.getStore();
-    if (!ctx) {
-      return;
-    }
-    for (const key of [...ctx.memo.keys()]) {
-      if (prefixes.some((p) => key.startsWith(p))) {
-        ctx.memo.delete(key);
-      }
-    }
-  }
-
-  /**
    * Drain any pending `invalidateDeferred` calls in the current request
    * scope. Called automatically by `get` before each cache read.
    * Safe to call when no scope is active (no-op).

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -90,7 +90,9 @@ export class ProjectCacheService {
     await this.flushDeferred();
 
     const cached = await this.redis.getJson<T>(key);
-    if (cached !== null) return cached;
+    if (cached !== null) {
+      return cached;
+    }
 
     const fresh = await loader();
     if (fresh !== undefined && fresh !== null) {
@@ -155,7 +157,9 @@ export class ProjectCacheService {
     await this.flushDeferred();
 
     const result = new Map<string, T>();
-    if (keys.length === 0) return result;
+    if (keys.length === 0) {
+      return result;
+    }
 
     const cached = await this.redis.mgetJson<T>(keys);
     const missingKeys: string[] = [];
@@ -215,7 +219,9 @@ export class ProjectCacheService {
    */
   private async flushDeferred(): Promise<void> {
     const ctx = requestContext.getStore();
-    if (!ctx || ctx.deferredCacheInvalidations.size === 0) return;
+    if (!ctx || ctx.deferredCacheInvalidations.size === 0) {
+      return;
+    }
     const keys = [...ctx.deferredCacheInvalidations];
     ctx.deferredCacheInvalidations.clear();
     await this.invalidate(keys);

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ContentDataType } from '@usertour/types';
 import { RedisService } from './redis.service';
 import { createRequestContext, requestContext } from './request-context';
 
@@ -178,5 +179,15 @@ export class ProjectCacheService {
       this.keys.themes(projectId),
       this.keys.projectLicense(projectId),
     ]);
+  }
+
+  /**
+   * Cache keys covering every content-type slice for an environment.
+   * Admin write paths usually don't know which slices changed —
+   * `await cache.invalidate(cache.envContentKeys(envId))` wipes them all
+   * with a single Redis DEL.
+   */
+  envContentKeys(envId: string): string[] {
+    return Object.values(ContentDataType).map((type) => this.keys.contents(envId, type));
   }
 }

--- a/apps/server/src/shared/redis.service.ts
+++ b/apps/server/src/shared/redis.service.ts
@@ -115,6 +115,42 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     await this.client.del(...list);
   }
 
+  /**
+   * Batch read JSON values for many keys. Returns one entry per input key
+   * in the same order; null for cache miss or parse failure.
+   */
+  async mgetJson<T>(keys: string[]): Promise<(T | null)[]> {
+    if (!this.client) {
+      throw new Error('Redis client not available');
+    }
+    if (keys.length === 0) return [];
+    const raws = await this.client.mget(...keys);
+    return raws.map((raw) => {
+      if (raw === null) return null;
+      try {
+        return JSON.parse(raw) as T;
+      } catch {
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Pipelined SETEX for many key/value pairs. One round-trip total.
+   */
+  async setJsonExMany<T>(entries: Array<[string, T]>, ttlSeconds: number): Promise<void> {
+    if (!this.client) {
+      throw new Error('Redis client not available');
+    }
+    if (entries.length === 0) return;
+    const pipeline = this.client.pipeline();
+    for (const [key, value] of entries) {
+      if (value === undefined || value === null) continue;
+      pipeline.setex(key, ttlSeconds, JSON.stringify(value));
+    }
+    await pipeline.exec();
+  }
+
   async acquireLock(key: string): Promise<LockReleaseFn | null> {
     if (!this.client) {
       throw new Error('Redis client not available');

--- a/apps/server/src/shared/redis.service.ts
+++ b/apps/server/src/shared/redis.service.ts
@@ -74,6 +74,47 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     return this.client.get(key);
   }
 
+  /**
+   * Read a JSON-serialized value. Returns null on miss or parse failure.
+   * Date / BigInt / Map / Set are NOT preserved — callers must only cache
+   * values that survive a round-trip through JSON.
+   */
+  async getJson<T>(key: string): Promise<T | null> {
+    if (!this.client) {
+      throw new Error('Redis client not available');
+    }
+    const raw = await this.client.get(key);
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      this.logger.warn(`Failed to parse cached value for ${key}: ${err}`);
+      return null;
+    }
+  }
+
+  /**
+   * Store a JSON-serialized value with TTL in seconds.
+   * Skips entirely on undefined/null to avoid caching empty results
+   * (callers that want to cache "negative" lookups should pass an explicit sentinel).
+   */
+  async setJsonEx<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    if (!this.client) {
+      throw new Error('Redis client not available');
+    }
+    if (value === undefined || value === null) return;
+    await this.client.setex(key, ttlSeconds, JSON.stringify(value));
+  }
+
+  async del(keys: string | string[]): Promise<void> {
+    if (!this.client) {
+      throw new Error('Redis client not available');
+    }
+    const list = Array.isArray(keys) ? keys : [keys];
+    if (list.length === 0) return;
+    await this.client.del(...list);
+  }
+
   async acquireLock(key: string): Promise<LockReleaseFn | null> {
     if (!this.client) {
       throw new Error('Redis client not available');

--- a/apps/server/src/shared/redis.service.ts
+++ b/apps/server/src/shared/redis.service.ts
@@ -84,7 +84,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
       throw new Error('Redis client not available');
     }
     const raw = await this.client.get(key);
-    if (raw === null) return null;
+    if (raw === null) {
+      return null;
+    }
     try {
       return JSON.parse(raw) as T;
     } catch (err) {
@@ -102,7 +104,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     if (!this.client) {
       throw new Error('Redis client not available');
     }
-    if (value === undefined || value === null) return;
+    if (value === undefined || value === null) {
+      return;
+    }
     await this.client.setex(key, ttlSeconds, JSON.stringify(value));
   }
 
@@ -111,7 +115,9 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
       throw new Error('Redis client not available');
     }
     const list = Array.isArray(keys) ? keys : [keys];
-    if (list.length === 0) return;
+    if (list.length === 0) {
+      return;
+    }
     await this.client.del(...list);
   }
 
@@ -123,10 +129,14 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     if (!this.client) {
       throw new Error('Redis client not available');
     }
-    if (keys.length === 0) return [];
+    if (keys.length === 0) {
+      return [];
+    }
     const raws = await this.client.mget(...keys);
     return raws.map((raw) => {
-      if (raw === null) return null;
+      if (raw === null) {
+        return null;
+      }
       try {
         return JSON.parse(raw) as T;
       } catch {
@@ -142,10 +152,14 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     if (!this.client) {
       throw new Error('Redis client not available');
     }
-    if (entries.length === 0) return;
+    if (entries.length === 0) {
+      return;
+    }
     const pipeline = this.client.pipeline();
     for (const [key, value] of entries) {
-      if (value === undefined || value === null) continue;
+      if (value === undefined || value === null) {
+        continue;
+      }
       pipeline.setex(key, ttlSeconds, JSON.stringify(value));
     }
     await pipeline.exec();

--- a/apps/server/src/shared/request-context.ts
+++ b/apps/server/src/shared/request-context.ts
@@ -1,9 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { BizUser } from '@prisma/client';
 
 /**
  * Per-request mutable state used to defer cross-cutting concerns
- * (currently: cache invalidation) until the request boundary, so they
- * fire AFTER any embedded $transaction has committed.
+ * (currently: cache invalidation, BizUser lookup memo) until the request
+ * boundary, so deferred invalidations fire AFTER any embedded $transaction
+ * has committed and per-request memos are released cleanly.
  *
  * The "request" here is whatever scope the entry-point wraps in
  * `requestContext.run(...)`: typically a websocket message handler call
@@ -13,10 +15,21 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 export interface RequestContext {
   /** Cache keys to invalidate after the current request scope completes. */
   deferredCacheInvalidations: Set<string>;
+  /**
+   * BizUser lookup memo keyed by `${envId}:${externalUserId}`. Stores the
+   * in-flight Promise (not the resolved value) so concurrent loaders coalesce
+   * into a single DB query. Holds whatever the first caller fetched: callers
+   * that need stricter freshness (e.g. tx-bound reads after a write) must
+   * bypass the memo and query directly.
+   */
+  bizUserMemo: Map<string, Promise<BizUser | null>>;
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>();
 
 export function createRequestContext(): RequestContext {
-  return { deferredCacheInvalidations: new Set<string>() };
+  return {
+    deferredCacheInvalidations: new Set<string>(),
+    bizUserMemo: new Map(),
+  };
 }

--- a/apps/server/src/shared/request-context.ts
+++ b/apps/server/src/shared/request-context.ts
@@ -1,0 +1,22 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Per-request mutable state used to defer cross-cutting concerns
+ * (currently: cache invalidation) until the request boundary, so they
+ * fire AFTER any embedded $transaction has committed.
+ *
+ * The "request" here is whatever scope the entry-point wraps in
+ * `requestContext.run(...)`: typically a websocket message handler call
+ * or an admin mutation. Service methods inside that scope read the store
+ * via `requestContext.getStore()` and append work to be drained at exit.
+ */
+export interface RequestContext {
+  /** Cache keys to invalidate after the current request scope completes. */
+  deferredCacheInvalidations: Set<string>;
+}
+
+export const requestContext = new AsyncLocalStorage<RequestContext>();
+
+export function createRequestContext(): RequestContext {
+  return { deferredCacheInvalidations: new Set<string>() };
+}

--- a/apps/server/src/shared/request-context.ts
+++ b/apps/server/src/shared/request-context.ts
@@ -1,11 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { BizUser } from '@prisma/client';
 
 /**
  * Per-request mutable state used to defer cross-cutting concerns
- * (currently: cache invalidation, BizUser lookup memo) until the request
- * boundary, so deferred invalidations fire AFTER any embedded $transaction
- * has committed and per-request memos are released cleanly.
+ * (cache invalidation, lookup memos) until the request boundary, so
+ * deferred invalidations fire AFTER any embedded $transaction has
+ * committed and per-request memos are released cleanly.
  *
  * The "request" here is whatever scope the entry-point wraps in
  * `requestContext.run(...)`: typically a websocket message handler call
@@ -16,13 +15,16 @@ export interface RequestContext {
   /** Cache keys to invalidate after the current request scope completes. */
   deferredCacheInvalidations: Set<string>;
   /**
-   * BizUser lookup memo keyed by `${envId}:${externalUserId}`. Stores the
-   * in-flight Promise (not the resolved value) so concurrent loaders coalesce
-   * into a single DB query. Holds whatever the first caller fetched: callers
-   * that need stricter freshness (e.g. tx-bound reads after a write) must
-   * bypass the memo and query directly.
+   * Coalesces same-scope repeated lookups into one DB query. Keys are
+   * `${namespace}:${callerKey}` to keep distinct entity types from
+   * colliding when callers happen to share an identifier shape. Stores
+   * in-flight Promises so concurrent loaders share the same query.
+   *
+   * Holds whatever the first caller fetched: paths that need stricter
+   * freshness (e.g. tx-bound reads after a write) must bypass the memo
+   * and query directly.
    */
-  bizUserMemo: Map<string, Promise<BizUser | null>>;
+  memo: Map<string, Promise<unknown>>;
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>();
@@ -30,6 +32,6 @@ export const requestContext = new AsyncLocalStorage<RequestContext>();
 export function createRequestContext(): RequestContext {
   return {
     deferredCacheInvalidations: new Set<string>(),
-    bizUserMemo: new Map(),
+    memo: new Map(),
   };
 }

--- a/apps/server/src/shared/shared.module.ts
+++ b/apps/server/src/shared/shared.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RedisService } from './redis.service';
 import { EncryptionService } from './encryption.service';
+import { ProjectCacheService } from './project-cache.service';
 
 @Module({
-  providers: [RedisService, EncryptionService],
-  exports: [RedisService, EncryptionService],
+  providers: [RedisService, EncryptionService, ProjectCacheService],
+  exports: [RedisService, EncryptionService, ProjectCacheService],
 })
 export class SharedModule {}

--- a/apps/server/src/themes/themes.module.ts
+++ b/apps/server/src/themes/themes.module.ts
@@ -1,11 +1,12 @@
 import { ProjectsModule } from '@/projects/projects.module';
+import { SharedModule } from '@/shared/shared.module';
 import { ThemesGuard } from '@/themes/themes.guard';
 import { ThemesResolver } from '@/themes/themes.resolver';
 import { ThemesService } from '@/themes/themes.service';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [ProjectsModule],
+  imports: [ProjectsModule, SharedModule],
   providers: [ThemesResolver, ThemesService, ThemesGuard],
   exports: [ThemesService],
 })

--- a/apps/server/src/themes/themes.service.ts
+++ b/apps/server/src/themes/themes.service.ts
@@ -2,25 +2,33 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'nestjs-prisma';
 import { CopyThemeInput, CreateThemeInput, UpdateThemeInput } from './dto/theme.input';
 import { ParamsError } from '@/common/errors';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 @Injectable()
 export class ThemesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly cache: ProjectCacheService,
+  ) {}
 
   async createTheme(data: CreateThemeInput) {
     if (data.isDefault) {
       await this.unsetThemeDefault(data.projectId);
     }
-    return await this.prisma.theme.create({
+    const created = await this.prisma.theme.create({
       data,
     });
+    await this.cache.invalidate(this.cache.keys.themes(created.projectId));
+    return created;
   }
 
   async unsetThemeDefault(projectId: string) {
-    return await this.prisma.theme.updateMany({
+    const result = await this.prisma.theme.updateMany({
       where: { isDefault: true, projectId },
       data: { isDefault: false },
     });
+    await this.cache.invalidate(this.cache.keys.themes(projectId));
+    return result;
   }
 
   async setDefaultTheme(themeId: string) {
@@ -29,10 +37,12 @@ export class ThemesService {
       throw new ParamsError();
     }
     await this.unsetThemeDefault(theme.projectId);
-    return await this.prisma.theme.update({
+    const updated = await this.prisma.theme.update({
       where: { id: themeId },
       data: { isDefault: true },
     });
+    await this.cache.invalidate(this.cache.keys.themes(updated.projectId));
+    return updated;
   }
 
   async updateTheme(data: UpdateThemeInput) {
@@ -41,10 +51,12 @@ export class ThemesService {
     if (!theme || theme.isSystem) {
       throw new ParamsError();
     }
-    return await this.prisma.theme.update({
+    const updated = await this.prisma.theme.update({
       where: { id },
       data: { ...others },
     });
+    await this.cache.invalidate(this.cache.keys.themes(updated.projectId));
+    return updated;
   }
 
   async getTheme(id: string) {
@@ -58,9 +70,11 @@ export class ThemesService {
     if (theme.isSystem || theme.isDefault) {
       throw new ParamsError();
     }
-    return await this.prisma.theme.delete({
+    const deleted = await this.prisma.theme.delete({
       where: { id },
     });
+    await this.cache.invalidate(this.cache.keys.themes(deleted.projectId));
+    return deleted;
   }
 
   async copyTheme(input: CopyThemeInput) {

--- a/apps/server/src/web-socket/core/condition-evaluation.service.spec.ts
+++ b/apps/server/src/web-socket/core/condition-evaluation.service.spec.ts
@@ -4,6 +4,7 @@ import {
   ConditionEvaluationContext,
 } from './condition-evaluation.service';
 import { PrismaService } from 'nestjs-prisma';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 import {
   RulesCondition,
   BizAttributeTypes,
@@ -188,6 +189,15 @@ describe('ConditionEvaluationService', () => {
         {
           provide: PrismaService,
           useValue: mockPrismaService,
+        },
+        {
+          // memoize without a request scope just runs the loader, matching
+          // the production fallback path; the unit tests don't exercise
+          // cross-call deduplication so this is sufficient.
+          provide: ProjectCacheService,
+          useValue: {
+            memoize: <T>(_namespace: string, _key: string, loader: () => Promise<T>) => loader(),
+          },
         },
       ],
     }).compile();

--- a/apps/server/src/web-socket/core/condition-evaluation.service.spec.ts
+++ b/apps/server/src/web-socket/core/condition-evaluation.service.spec.ts
@@ -196,7 +196,14 @@ describe('ConditionEvaluationService', () => {
           // cross-call deduplication so this is sufficient.
           provide: ProjectCacheService,
           useValue: {
-            memoize: <T>(_namespace: string, _key: string, loader: () => Promise<T>) => loader(),
+            memoize: <T>(_key: string, loader: () => Promise<T>) => loader(),
+            memoKeys: {
+              bizUserOnCompanyWithBizCompany: (
+                bizUserId: string,
+                envId: string,
+                externalCompanyId: string,
+              ) => `bizUserOnCompanyWithBizCompany:${bizUserId}:${envId}:${externalCompanyId}`,
+            },
           },
         },
       ],

--- a/apps/server/src/web-socket/core/condition-evaluation.service.ts
+++ b/apps/server/src/web-socket/core/condition-evaluation.service.ts
@@ -1,6 +1,7 @@
 import { AttributeBizType } from '@/attributes/models/attribute.model';
 import { SegmentBizType, SegmentDataType } from '@/biz/models/segment.model';
 import { createConditionsFilter } from '@/common/attribute/filter';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 import { evaluateAttributeCondition, isArray, isNullish } from '@usertour/helpers';
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from 'nestjs-prisma';
@@ -89,7 +90,10 @@ type ContentConditionParams = {
 export class ConditionEvaluationService {
   private readonly logger = new Logger(ConditionEvaluationService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: ProjectCacheService,
+  ) {}
 
   // ============================================================================
   // Public API Methods
@@ -706,23 +710,30 @@ export class ConditionEvaluationService {
   }
 
   /**
-   * Find user-company relationship with company included
-   * @param context - Condition evaluation context
-   * @returns User-company relationship with company, or null if not found
+   * Find user-company relationship with company included.
+   * Memoized per request scope so repeated condition evaluations across the
+   * 6-type toggleContents loop don't all re-query the same membership row.
+   * Distinct namespace from `bizUserOnCompany` because the included
+   * `bizCompany` shape differs from the bare row.
    */
   private async findUserCompanyRelation(context: ConditionEvaluationContext) {
-    return await this.prisma.bizUserOnCompany.findFirst({
-      where: {
-        bizUserId: context.bizUser.id,
-        bizCompany: {
-          externalId: String(context.externalCompanyId),
-          environmentId: context.environment.id,
-        },
-      },
-      include: {
-        bizCompany: true,
-      },
-    });
+    return this.cache.memoize(
+      'bizUserOnCompanyWithBizCompany',
+      `${context.bizUser.id}:${context.environment.id}:${String(context.externalCompanyId)}`,
+      () =>
+        this.prisma.bizUserOnCompany.findFirst({
+          where: {
+            bizUserId: context.bizUser.id,
+            bizCompany: {
+              externalId: String(context.externalCompanyId),
+              environmentId: context.environment.id,
+            },
+          },
+          include: {
+            bizCompany: true,
+          },
+        }),
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/condition-evaluation.service.ts
+++ b/apps/server/src/web-socket/core/condition-evaluation.service.ts
@@ -718,8 +718,11 @@ export class ConditionEvaluationService {
    */
   private async findUserCompanyRelation(context: ConditionEvaluationContext) {
     return this.cache.memoize(
-      'bizUserOnCompanyWithBizCompany',
-      `${context.bizUser.id}:${context.environment.id}:${String(context.externalCompanyId)}`,
+      this.cache.memoKeys.bizUserOnCompanyWithBizCompany(
+        context.bizUser.id,
+        context.environment.id,
+        String(context.externalCompanyId),
+      ),
       () =>
         this.prisma.bizUserOnCompany.findFirst({
           where: {
@@ -737,10 +740,14 @@ export class ConditionEvaluationService {
   }
 
   /**
-   * Check if there is an available session for a content and user
-   * @param contentId - The ID of the content
-   * @param bizUserId - The ID of the business user
-   * @returns true if an available session exists, false otherwise
+   * Check if there is an available session for a content and user.
+   *
+   * NOT memoized: toggleContents may create new BizSessions mid-EndBatch
+   * (one content type's auto-start fires, then another type's rules ask
+   * "is content X activated?"), and a memo'd pre-creation `false` would
+   * mask the just-created session. The repeated calls within one
+   * evaluation pass hit a hot DB row anyway — cheaper than getting the
+   * answer wrong.
    */
   private async hasAvailableSession(contentId: string, bizUserId: string): Promise<boolean> {
     const count = await this.prisma.bizSession.count({
@@ -750,22 +757,20 @@ export class ConditionEvaluationService {
   }
 
   /**
-   * Check if the user has a biz event
-   * @param contentId - The ID of the content
-   * @param bizUserId - The ID of the business user
-   * @param eventCodeName - The code names of the events (array of strings)
-   * @returns true if the user has any of the events, false otherwise
+   * Check if the user has a biz event.
+   *
+   * NOT memoized for the same reason as hasAvailableSession: trackBizEvent
+   * fires SEEN / COMPLETED events as toggleContents progresses, and a
+   * memo'd pre-event `false` would hide the new event from later rules.
    */
   private async hasBizEvent(
     contentId: string,
     bizUserId: string,
     eventCodeName: string[],
   ): Promise<boolean> {
-    // Early return if no events to check
     if (!eventCodeName || eventCodeName.length === 0) {
       return false;
     }
-
     const count = await this.prisma.bizSession.count({
       where: {
         contentId,

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -383,24 +383,37 @@ export class ContentDataService {
       return version ? [version] : [];
     }
 
-    // Find all published versions with content, filtered by contentTypes in Prisma query
-    const publishedContents = await this.prisma.content.findMany({
-      where: {
-        deleted: false,
-        contentOnEnvironments: {
-          some: {
-            environmentId: environment.id,
-            published: true,
+    // Find all published Contents (with their ContentOnEnvironment join rows)
+    // for this env + type filter. Cached only when filtering by a single type
+    // (which is what the toggleContents loop and handleChecklistCompletedEvents
+    // always do); a multi-type query is rare enough to skip caching for.
+    const fetchPublishedContents = () =>
+      this.prisma.content.findMany({
+        where: {
+          deleted: false,
+          contentOnEnvironments: {
+            some: {
+              environmentId: environment.id,
+              published: true,
+            },
+          },
+          type: {
+            in: contentTypes,
           },
         },
-        type: {
-          in: contentTypes,
+        include: {
+          contentOnEnvironments: true,
         },
-      },
-      include: {
-        contentOnEnvironments: true,
-      },
-    });
+      });
+
+    const publishedContents =
+      contentTypes.length === 1
+        ? await this.cache.getOrFetch(
+            this.cache.keys.contents(environment.id, contentTypes[0]),
+            ContentDataService.PROJECT_CONFIG_TTL_SECONDS,
+            fetchPublishedContents,
+          )
+        : await fetchPublishedContents();
 
     // Extract version IDs for published contents
     const versionIds = publishedContents

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -349,12 +349,22 @@ export class ContentDataService {
   }
 
   /**
-   * Find themes by project ID
+   * Find themes by project ID.
+   *
+   * Cached per project: result depends only on projectId. Invalidated by
+   * ThemesService on every create/update/delete. Theme has Date columns
+   * but none are read in the EndBatch / session-builder hot path so the
+   * JSON round trip is safe.
    */
   private async findThemesByProject(environment: Environment): Promise<Theme[]> {
-    return await this.prisma.theme.findMany({
-      where: { projectId: environment.projectId },
-    });
+    return await this.cache.get(
+      this.cache.keys.themes(environment.projectId),
+      ContentDataService.PROJECT_CONFIG_TTL_SECONDS,
+      () =>
+        this.prisma.theme.findMany({
+          where: { projectId: environment.projectId },
+        }),
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -32,6 +32,7 @@ import {
   ConditionEvaluationContext,
 } from './condition-evaluation.service';
 import { DISMISSED_EVENTS } from '@/utils/event-v2';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 // ============================================================================
 // Type Definitions
@@ -114,7 +115,12 @@ export class ContentDataService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly conditionEvaluationService: ConditionEvaluationService,
+    private readonly cache: ProjectCacheService,
   ) {}
+
+  /** TTL for project-level cached configuration. Long enough to absorb most
+   *  reads but short enough that any missed invalidation self-heals quickly. */
+  private static readonly PROJECT_CONFIG_TTL_SECONDS = 5 * 60;
 
   // ============================================================================
   // Public API Methods
@@ -313,17 +319,28 @@ export class ContentDataService {
   }
 
   /**
-   * Find attributes for content processing
+   * Find attributes for content processing.
+   *
+   * Cached per project: the result depends only on projectId + the fixed
+   * CONTENT_ATTRIBUTE_BIZ_TYPES filter, and only changes when the admin
+   * mutates Attribute rows (handled by AttributesService write path).
+   * Attribute has Date columns but none of the hot-path consumers read
+   * them, so caching the entity as-is is safe.
    */
   private async findAttributes(environment: Environment): Promise<Attribute[]> {
-    return await this.prisma.attribute.findMany({
-      where: {
-        projectId: environment.projectId,
-        bizType: {
-          in: [...ContentDataService.CONTENT_ATTRIBUTE_BIZ_TYPES],
-        },
-      },
-    });
+    return await this.cache.getOrFetch(
+      this.cache.keys.attrs(environment.projectId),
+      ContentDataService.PROJECT_CONFIG_TTL_SECONDS,
+      () =>
+        this.prisma.attribute.findMany({
+          where: {
+            projectId: environment.projectId,
+            bizType: {
+              in: [...ContentDataService.CONTENT_ATTRIBUTE_BIZ_TYPES],
+            },
+          },
+        }),
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -288,22 +288,20 @@ export class ContentDataService {
   }
 
   /**
-   * Check if the user has a biz event
-   * @param contentId - The ID of the content
-   * @param bizUserId - The ID of the business user
-   * @param eventCodeNames - The code names of the events (array of strings)
-   * @returns true if the user has any of the events, false otherwise
+   * Check if the user has a biz event.
+   *
+   * NOT memoized: trackBizEvent fires SEEN / COMPLETED events mid-EndBatch
+   * as toggleContents starts new sessions, so a memo'd pre-event answer
+   * would hide just-fired events from later condition evaluation.
    */
   async hasBizEvent(
     contentId: string,
     bizUserId: string,
     eventCodeNames: string[],
   ): Promise<boolean> {
-    // Early return if no events to check
     if (!eventCodeNames || eventCodeNames.length === 0) {
       return false;
     }
-
     const count = await this.prisma.bizSession.count({
       where: {
         contentId,
@@ -327,10 +325,12 @@ export class ContentDataService {
     environment: Environment,
     externalUserId: string,
   ): Promise<BizUser | null> {
-    return this.cache.memoize('bizUser', `${environment.id}:${String(externalUserId)}`, () =>
-      this.prisma.bizUser.findFirst({
-        where: { externalId: String(externalUserId), environmentId: environment.id },
-      }),
+    return this.cache.memoize(
+      this.cache.memoKeys.bizUser(environment.id, String(externalUserId)),
+      () =>
+        this.prisma.bizUser.findFirst({
+          where: { externalId: String(externalUserId), environmentId: environment.id },
+        }),
     );
   }
 

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -122,6 +122,11 @@ export class ContentDataService {
    *  reads but short enough that any missed invalidation self-heals quickly. */
   private static readonly PROJECT_CONFIG_TTL_SECONDS = 5 * 60;
 
+  /** TTL for published Version rows (full include with steps + content).
+   *  Longer than project-config because published versions are immutable —
+   *  see findVersions for the invariant this depends on. */
+  private static readonly PUBLISHED_VERSION_TTL_SECONDS = 30 * 60;
+
   // ============================================================================
   // Public API Methods
   // ============================================================================
@@ -328,7 +333,7 @@ export class ContentDataService {
    * them, so caching the entity as-is is safe.
    */
   private async findAttributes(environment: Environment): Promise<Attribute[]> {
-    return await this.cache.getOrFetch(
+    return await this.cache.get(
       this.cache.keys.attrs(environment.projectId),
       ContentDataService.PROJECT_CONFIG_TTL_SECONDS,
       () =>
@@ -353,34 +358,49 @@ export class ContentDataService {
   }
 
   /**
-   * Find versions for content processing
-   * @param environment - The environment
-   * @param contentTypes - Content types array to filter by
-   * @param versionId - Optional specific version ID
+   * Find versions for content processing.
+   *
+   * INVARIANT (cache assumption): a Version row that is currently published
+   * — i.e. referenced by a `ContentOnEnvironment.publishedVersionId` —
+   * is immutable. All admin write paths reject mutations on a version that
+   * is not the current edited draft (`contentVersionIsEditable` checks
+   * `editedVersionId === versionId` AND `not currently published`). Step
+   * mutation methods (`addContentStep` / `updateContentStep`) use the same
+   * gate. Therefore we cache `version:{id}:full` with a long TTL and
+   * **do not invalidate from any write path** — anything in the cache is,
+   * by construction, the final state of that version.
+   *
+   * If product behavior ever changes to allow editing already-published
+   * versions, every such write site MUST call
+   * `cache.invalidate(cache.keys.versionFull(versionId))` and this TTL
+   * should be shortened.
    */
   private async findVersions(
     environment: Environment,
     contentTypes: ContentDataType[],
     versionId?: string,
   ): Promise<VersionWithStepsAndContent[]> {
-    if (versionId) {
-      // Find the specific version with content, filtered by contentTypes in Prisma query
-      const version = await this.prisma.version.findFirst({
-        where: {
-          id: versionId,
-          content: {
-            type: {
-              in: contentTypes,
-            },
-          },
-        },
+    const fetchVersionById = (id: string) =>
+      this.prisma.version.findUnique({
+        where: { id },
         include: {
           content: true,
           steps: { orderBy: { sequence: 'asc' } },
         },
       });
 
-      return version ? [version] : [];
+    if (versionId) {
+      const version = await this.cache.get(
+        this.cache.keys.versionFull(versionId),
+        ContentDataService.PUBLISHED_VERSION_TTL_SECONDS,
+        () => fetchVersionById(versionId),
+      );
+      // The original query also filtered by content.type IN contentTypes;
+      // apply post-cache since the cache key is per-version-id.
+      if (!version || !contentTypes.includes(version.content.type as ContentDataType)) {
+        return [];
+      }
+      return [version];
     }
 
     // Find all published Contents (with their ContentOnEnvironment join rows)
@@ -408,7 +428,7 @@ export class ContentDataService {
 
     const publishedContents =
       contentTypes.length === 1
-        ? await this.cache.getOrFetch(
+        ? await this.cache.get(
             this.cache.keys.contents(environment.id, contentTypes[0]),
             ContentDataService.PROJECT_CONFIG_TTL_SECONDS,
             fetchPublishedContents,
@@ -420,14 +440,31 @@ export class ContentDataService {
       .map((content) => getPublishedVersionId(content, environment.id))
       .filter(Boolean);
 
-    // Find versions with content and steps
-    return await this.prisma.version.findMany({
-      where: { id: { in: versionIds } },
-      include: {
-        content: true,
-        steps: { orderBy: { sequence: 'asc' } },
+    if (versionIds.length === 0) return [];
+
+    // Per-version cache; published Version data is immutable so a long TTL
+    // is safe (see invariant doc above). MGET reads all keys in one round
+    // trip; misses are loaded with a single findMany so we don't regress
+    // cold-cache cost vs the original batched query.
+    const keyToId = new Map(versionIds.map((id) => [this.cache.keys.versionFull(id), id]));
+    const cached = await this.cache.mget<VersionWithStepsAndContent>(
+      [...keyToId.keys()],
+      ContentDataService.PUBLISHED_VERSION_TTL_SECONDS,
+      async (missingKeys) => {
+        const missingIds = missingKeys.map((k) => keyToId.get(k) as string);
+        const fresh = await this.prisma.version.findMany({
+          where: { id: { in: missingIds } },
+          include: {
+            content: true,
+            steps: { orderBy: { sequence: 'asc' } },
+          },
+        });
+        return new Map(fresh.map((v) => [this.cache.keys.versionFull(v.id), v]));
       },
-    });
+    );
+    return versionIds
+      .map((id) => cached.get(this.cache.keys.versionFull(id)))
+      .filter((v): v is VersionWithStepsAndContent => v != null);
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -228,6 +228,10 @@ export class ContentDataService {
             environmentId,
             contentId,
             published: true,
+            // Defense in depth: deleteContent already drops COE rows,
+            // but a stale row from any other write path would otherwise
+            // resurface a deleted content's versionId via this cache.
+            content: { deleted: false },
           },
           select: {
             publishedVersionId: true,
@@ -382,30 +386,32 @@ export class ContentDataService {
    * Find versions for content processing.
    *
    * INVARIANT (cache assumption): a Version row that is currently published
-   * — i.e. referenced by a `ContentOnEnvironment.publishedVersionId` —
-   * is immutable. All admin write paths reject mutations on a version that
-   * is not the current edited draft (`contentVersionIsEditable` checks
-   * `editedVersionId === versionId` AND `not currently published`). Step
-   * mutation methods (`addContentStep` / `updateContentStep`) use the same
-   * gate. Therefore we cache `version:{id}:full` with a long TTL and
-   * **do not invalidate from any write path** — anything in the cache is,
-   * by construction, the final state of that version.
+   * is immutable, AND the Content fields we co-cache with it (`{id, type}`)
+   * are structurally immutable too — `id` is the PK, `type` cannot be
+   * changed by any update path. Mutable Content fields (name, buildUrl,
+   * config) live in the env+type slice cache (write-invalidated) and are
+   * re-attached at read time. So `versionFull` never needs invalidation
+   * from any Content rename / update.
    *
-   * If product behavior ever changes to allow editing already-published
-   * versions, every such write site MUST call
-   * `cache.invalidate(cache.keys.versionFull(versionId))` and this TTL
-   * should be shortened.
+   * The split is by field mutability, not by entity boundary: caching
+   * immutable Content fields here is free (no invalidation cost) and lets
+   * the explicit-versionId path early-return on a type-filter miss without
+   * touching the DB.
    */
   private async findVersions(
     environment: Environment,
     contentTypes: ContentDataType[],
     versionId?: string,
   ): Promise<VersionWithStepsAndContent[]> {
-    const fetchVersionById = (id: string) =>
-      this.prisma.version.findUnique({
-        where: { id },
+    // Defense in depth on the cache loader: only pin Versions whose Content
+    // is still alive. The `where: content.deleted: false` clause prevents a
+    // stale source from materializing a deleted-content version into the
+    // 30-minute TTL.
+    const fetchVersionLite = (id: string) =>
+      this.prisma.version.findFirst({
+        where: { id, deleted: false, content: { deleted: false } },
         include: {
-          content: true,
+          content: { select: { id: true, type: true } },
           steps: { orderBy: { sequence: 'asc' } },
         },
       });
@@ -414,14 +420,21 @@ export class ContentDataService {
       const version = await this.cache.get(
         this.cache.keys.versionFull(versionId),
         ContentDataService.PUBLISHED_VERSION_TTL_SECONDS,
-        () => fetchVersionById(versionId),
+        () => fetchVersionLite(versionId),
       );
-      // The original query also filtered by content.type IN contentTypes;
-      // apply post-cache since the cache key is per-version-id.
       if (!version || !contentTypes.includes(version.content.type as ContentDataType)) {
         return [];
       }
-      return [version];
+      // Re-fetch the full Content row so callers get the latest mutable
+      // fields (name, etc.), and so a delete that landed after the cache
+      // populated drops the version from the result set.
+      const content = await this.prisma.content.findFirst({
+        where: { id: version.content.id, deleted: false },
+      });
+      if (!content) {
+        return [];
+      }
+      return [{ ...version, content }];
     }
 
     // Find all published Contents (with their ContentOnEnvironment join rows)
@@ -456,6 +469,10 @@ export class ContentDataService {
           )
         : await fetchPublishedContents();
 
+    // Map by id so we can re-attach the full Content row (with the latest
+    // name, etc.) onto the slim cached version below.
+    const contentById = new Map(publishedContents.map((content) => [content.id, content]));
+
     // Extract version IDs for published contents
     const versionIds = publishedContents
       .map((content) => getPublishedVersionId(content, environment.id))
@@ -466,19 +483,20 @@ export class ContentDataService {
     }
 
     // Per-version cache; published Version data is immutable so a long TTL
-    // is safe (see invariant doc above). MGET reads all keys in one round
-    // trip; misses are loaded with a single findMany so we don't regress
-    // cold-cache cost vs the original batched query.
+    // is safe. MGET reads all keys in one round trip; misses are loaded with
+    // a single findMany so we don't regress cold-cache cost vs the original
+    // batched query.
+    type CachedVersion = Awaited<ReturnType<typeof fetchVersionLite>>;
     const keyToId = new Map(versionIds.map((id) => [this.cache.keys.versionFull(id), id]));
-    const cached = await this.cache.mget<VersionWithStepsAndContent>(
+    const cached = await this.cache.mget<NonNullable<CachedVersion>>(
       [...keyToId.keys()],
       ContentDataService.PUBLISHED_VERSION_TTL_SECONDS,
       async (missingKeys) => {
         const missingIds = missingKeys.map((cacheKey) => keyToId.get(cacheKey) as string);
         const fresh = await this.prisma.version.findMany({
-          where: { id: { in: missingIds } },
+          where: { id: { in: missingIds }, deleted: false, content: { deleted: false } },
           include: {
-            content: true,
+            content: { select: { id: true, type: true } },
             steps: { orderBy: { sequence: 'asc' } },
           },
         });
@@ -486,8 +504,20 @@ export class ContentDataService {
       },
     );
     return versionIds
-      .map((id) => cached.get(this.cache.keys.versionFull(id)))
-      .filter((version): version is VersionWithStepsAndContent => version != null);
+      .map((id): VersionWithStepsAndContent | null => {
+        const version = cached.get(this.cache.keys.versionFull(id));
+        if (!version) {
+          return null;
+        }
+        const content = contentById.get(version.content.id);
+        // Slice-miss means the Content was filtered out (deleted /
+        // unpublished post-cache) — skip the version entirely.
+        if (!content) {
+          return null;
+        }
+        return { ...version, content };
+      })
+      .filter((version): version is VersionWithStepsAndContent => version !== null);
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -458,7 +458,9 @@ export class ContentDataService {
       .map((content) => getPublishedVersionId(content, environment.id))
       .filter(Boolean);
 
-    if (versionIds.length === 0) return [];
+    if (versionIds.length === 0) {
+      return [];
+    }
 
     // Per-version cache; published Version data is immutable so a long TTL
     // is safe (see invariant doc above). MGET reads all keys in one round
@@ -469,7 +471,7 @@ export class ContentDataService {
       [...keyToId.keys()],
       ContentDataService.PUBLISHED_VERSION_TTL_SECONDS,
       async (missingKeys) => {
-        const missingIds = missingKeys.map((k) => keyToId.get(k) as string);
+        const missingIds = missingKeys.map((cacheKey) => keyToId.get(cacheKey) as string);
         const fresh = await this.prisma.version.findMany({
           where: { id: { in: missingIds } },
           include: {
@@ -477,12 +479,12 @@ export class ContentDataService {
             steps: { orderBy: { sequence: 'asc' } },
           },
         });
-        return new Map(fresh.map((v) => [this.cache.keys.versionFull(v.id), v]));
+        return new Map(fresh.map((version) => [this.cache.keys.versionFull(version.id), version]));
       },
     );
     return versionIds
       .map((id) => cached.get(this.cache.keys.versionFull(id)))
-      .filter((v): v is VersionWithStepsAndContent => v != null);
+      .filter((version): version is VersionWithStepsAndContent => version != null);
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -327,7 +327,7 @@ export class ContentDataService {
     environment: Environment,
     externalUserId: string,
   ): Promise<BizUser | null> {
-    return this.cache.memoizeBizUser(environment.id, String(externalUserId), () =>
+    return this.cache.memoize('bizUser', `${environment.id}:${String(externalUserId)}`, () =>
       this.prisma.bizUser.findFirst({
         where: { externalId: String(externalUserId), environmentId: environment.id },
       }),

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -320,15 +320,18 @@ export class ContentDataService {
   // ============================================================================
 
   /**
-   * Find business user by external ID
+   * Find business user by external ID. Memoized per request scope so the
+   * 6-type toggleContents loop + findThemes don't all re-query the same row.
    */
   private async findBizUser(
     environment: Environment,
     externalUserId: string,
   ): Promise<BizUser | null> {
-    return await this.prisma.bizUser.findFirst({
-      where: { externalId: String(externalUserId), environmentId: environment.id },
-    });
+    return this.cache.memoizeBizUser(environment.id, String(externalUserId), () =>
+      this.prisma.bizUser.findFirst({
+        where: { externalId: String(externalUserId), environmentId: environment.id },
+      }),
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -210,24 +210,32 @@ export class ContentDataService {
   }
 
   /**
-   * Find published version ID by contentId and environmentId
-   * @param contentId - The content ID
-   * @param environmentId - The environment ID
-   * @returns Published version ID or undefined if not found
+   * Find published version ID by contentId and environmentId.
+   *
+   * Cached per (envId, contentId). Invalidated alongside the env's content
+   * slices on publish / unpublish / delete (see content.service.ts). The
+   * "no published" undefined result is intentionally not cached — its
+   * frequency is low and skipping the cache write avoids a sentinel value
+   * scheme.
    */
   async findPublishedVersionId(contentId: string, environmentId: string) {
-    const contentOnEnvironment = await this.prisma.contentOnEnvironment.findFirst({
-      where: {
-        environmentId,
-        contentId,
-        published: true,
+    return await this.cache.get(
+      this.cache.keys.publishedVersionId(environmentId, contentId),
+      ContentDataService.PROJECT_CONFIG_TTL_SECONDS,
+      async () => {
+        const contentOnEnvironment = await this.prisma.contentOnEnvironment.findFirst({
+          where: {
+            environmentId,
+            contentId,
+            published: true,
+          },
+          select: {
+            publishedVersionId: true,
+          },
+        });
+        return contentOnEnvironment?.publishedVersionId;
       },
-      select: {
-        publishedVersionId: true,
-      },
-    });
-
-    return contentOnEnvironment?.publishedVersionId;
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/session-builder.service.ts
+++ b/apps/server/src/web-socket/core/session-builder.service.ts
@@ -39,6 +39,7 @@ import { ContentDataService } from './content-data.service';
 import { ProjectsService } from '@/projects/projects.service';
 import { DistributedLockService } from './distributed-lock.service';
 import { buildSessionCreateLockKey } from '@/utils/websocket-utils';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 @Injectable()
 export class SessionBuilderService {
@@ -49,6 +50,7 @@ export class SessionBuilderService {
     private readonly contentDataService: ContentDataService,
     private readonly projectsService: ProjectsService,
     private readonly distributedLockService: DistributedLockService,
+    private readonly cache: ProjectCacheService,
   ) {}
 
   // ============================================================================
@@ -120,9 +122,11 @@ export class SessionBuilderService {
     versionId: string,
   ): Promise<BizSession | null> {
     const environmentId = environment.id;
-    const bizUser = await this.prisma.bizUser.findFirst({
-      where: { externalId: String(externalUserId), environmentId },
-    });
+    const bizUser = await this.cache.memoizeBizUser(environmentId, String(externalUserId), () =>
+      this.prisma.bizUser.findFirst({
+        where: { externalId: String(externalUserId), environmentId },
+      }),
+    );
     const bizCompany = await this.prisma.bizCompany.findFirst({
       where: { externalId: String(externalCompanyId), environmentId },
     });
@@ -301,18 +305,20 @@ export class SessionBuilderService {
     externalCompanyId?: string,
   ): Promise<any> {
     const environmentId = environment.id;
-    const bizUser = await this.prisma.bizUser.findFirst({
-      where: {
-        environmentId,
-        externalId: String(externalUserId),
-      },
-      select: {
-        data: true,
-        id: true,
-      },
-    });
+    // Drop the {data, id} projection so the per-request memo holds a
+    // consistent full BizUser entity across all callers in the scope.
+    const bizUser = await this.cache.memoizeBizUser(environmentId, String(externalUserId), () =>
+      this.prisma.bizUser.findFirst({
+        where: {
+          environmentId,
+          externalId: String(externalUserId),
+        },
+      }),
+    );
 
-    if (!bizUser) return null;
+    if (!bizUser) {
+      return null;
+    }
 
     if (attr.bizType === AttributeBizType.USER) {
       if (bizUser?.data) {

--- a/apps/server/src/web-socket/core/session-builder.service.ts
+++ b/apps/server/src/web-socket/core/session-builder.service.ts
@@ -123,16 +123,14 @@ export class SessionBuilderService {
   ): Promise<BizSession | null> {
     const environmentId = environment.id;
     const bizUser = await this.cache.memoize(
-      'bizUser',
-      `${environmentId}:${String(externalUserId)}`,
+      this.cache.memoKeys.bizUser(environmentId, String(externalUserId)),
       () =>
         this.prisma.bizUser.findFirst({
           where: { externalId: String(externalUserId), environmentId },
         }),
     );
     const bizCompany = await this.cache.memoize(
-      'bizCompany',
-      `${environmentId}:${String(externalCompanyId)}`,
+      this.cache.memoKeys.bizCompany(environmentId, String(externalCompanyId)),
       () =>
         this.prisma.bizCompany.findFirst({
           where: { externalId: String(externalCompanyId), environmentId },
@@ -316,8 +314,7 @@ export class SessionBuilderService {
     // Drop projections so per-request memos hold consistent full entities
     // across all callers in the scope.
     const bizUser = await this.cache.memoize(
-      'bizUser',
-      `${environmentId}:${String(externalUserId)}`,
+      this.cache.memoKeys.bizUser(environmentId, String(externalUserId)),
       () =>
         this.prisma.bizUser.findFirst({
           where: {
@@ -344,8 +341,7 @@ export class SessionBuilderService {
       }
 
       const bizCompany = await this.cache.memoize(
-        'bizCompany',
-        `${environmentId}:${String(externalCompanyId)}`,
+        this.cache.memoKeys.bizCompany(environmentId, String(externalCompanyId)),
         () =>
           this.prisma.bizCompany.findFirst({
             where: {
@@ -360,8 +356,7 @@ export class SessionBuilderService {
       }
 
       const userOnCompany = await this.cache.memoize(
-        'bizUserOnCompany',
-        `${bizUser.id}:${bizCompany.id}`,
+        this.cache.memoKeys.bizUserOnCompany(bizUser.id, bizCompany.id),
         () =>
           this.prisma.bizUserOnCompany.findFirst({
             where: {

--- a/apps/server/src/web-socket/core/session-builder.service.ts
+++ b/apps/server/src/web-socket/core/session-builder.service.ts
@@ -122,14 +122,22 @@ export class SessionBuilderService {
     versionId: string,
   ): Promise<BizSession | null> {
     const environmentId = environment.id;
-    const bizUser = await this.cache.memoizeBizUser(environmentId, String(externalUserId), () =>
-      this.prisma.bizUser.findFirst({
-        where: { externalId: String(externalUserId), environmentId },
-      }),
+    const bizUser = await this.cache.memoize(
+      'bizUser',
+      `${environmentId}:${String(externalUserId)}`,
+      () =>
+        this.prisma.bizUser.findFirst({
+          where: { externalId: String(externalUserId), environmentId },
+        }),
     );
-    const bizCompany = await this.prisma.bizCompany.findFirst({
-      where: { externalId: String(externalCompanyId), environmentId },
-    });
+    const bizCompany = await this.cache.memoize(
+      'bizCompany',
+      `${environmentId}:${String(externalCompanyId)}`,
+      () =>
+        this.prisma.bizCompany.findFirst({
+          where: { externalId: String(externalCompanyId), environmentId },
+        }),
+    );
     if (!bizUser || (externalCompanyId && !bizCompany)) {
       return null;
     }
@@ -305,15 +313,18 @@ export class SessionBuilderService {
     externalCompanyId?: string,
   ): Promise<any> {
     const environmentId = environment.id;
-    // Drop the {data, id} projection so the per-request memo holds a
-    // consistent full BizUser entity across all callers in the scope.
-    const bizUser = await this.cache.memoizeBizUser(environmentId, String(externalUserId), () =>
-      this.prisma.bizUser.findFirst({
-        where: {
-          environmentId,
-          externalId: String(externalUserId),
-        },
-      }),
+    // Drop projections so per-request memos hold consistent full entities
+    // across all callers in the scope.
+    const bizUser = await this.cache.memoize(
+      'bizUser',
+      `${environmentId}:${String(externalUserId)}`,
+      () =>
+        this.prisma.bizUser.findFirst({
+          where: {
+            environmentId,
+            externalId: String(externalUserId),
+          },
+        }),
     );
 
     if (!bizUser) {
@@ -328,28 +339,41 @@ export class SessionBuilderService {
     }
 
     if (attr.bizType === AttributeBizType.COMPANY || attr.bizType === AttributeBizType.MEMBERSHIP) {
-      if (!externalCompanyId) return null;
+      if (!externalCompanyId) {
+        return null;
+      }
 
-      const bizCompany = await this.prisma.bizCompany.findFirst({
-        where: {
-          externalId: String(externalCompanyId),
-          environmentId,
-        },
-      });
+      const bizCompany = await this.cache.memoize(
+        'bizCompany',
+        `${environmentId}:${String(externalCompanyId)}`,
+        () =>
+          this.prisma.bizCompany.findFirst({
+            where: {
+              externalId: String(externalCompanyId),
+              environmentId,
+            },
+          }),
+      );
 
-      if (!bizCompany) return null;
+      if (!bizCompany) {
+        return null;
+      }
 
-      const userOnCompany = await this.prisma.bizUserOnCompany.findFirst({
-        where: {
-          bizUserId: bizUser.id,
-          bizCompanyId: bizCompany.id,
-        },
-        select: {
-          data: true,
-        },
-      });
+      const userOnCompany = await this.cache.memoize(
+        'bizUserOnCompany',
+        `${bizUser.id}:${bizCompany.id}`,
+        () =>
+          this.prisma.bizUserOnCompany.findFirst({
+            where: {
+              bizUserId: bizUser.id,
+              bizCompanyId: bizCompany.id,
+            },
+          }),
+      );
 
-      if (!userOnCompany) return null;
+      if (!userOnCompany) {
+        return null;
+      }
 
       if (attr.bizType === AttributeBizType.COMPANY) {
         return getAttributeValue(bizCompany.data, attr.codeName);

--- a/apps/server/src/web-socket/v2/web-socket-v2-message-handler.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2-message-handler.ts
@@ -5,6 +5,7 @@ import { WebSocketV2Service } from './web-socket-v2.service';
 import { WebSocketContext } from './web-socket-v2.dto';
 import { DistributedLockService } from '../core/distributed-lock.service';
 import { buildSocketLockKey, getSocketToken } from '@/utils/websocket-utils';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 
 interface MessageHandler {
   handle(context: WebSocketContext, payload?: any): Promise<any>;
@@ -22,6 +23,7 @@ export class WebSocketV2MessageHandler {
   constructor(
     private readonly service: WebSocketV2Service,
     private readonly distributedLockService: DistributedLockService,
+    private readonly cache: ProjectCacheService,
   ) {
     this.registerHandlers();
   }
@@ -162,12 +164,24 @@ export class WebSocketV2MessageHandler {
     const startTime = Date.now();
     const lockKey = buildSocketLockKey(socket);
 
-    const result = await this.distributedLockService.withRetryLock(
-      lockKey,
-      () => this.handleMessage(server, socket, kind, payload),
-      5, // Retry 5 times (increased from 3 to handle concurrent message processing)
-      1000, // Retry interval 1000ms (allows sufficient time for message processing including DB operations)
-      5000, // Lock timeout 5 seconds
+    // runInScope establishes a per-message AsyncLocalStorage context so any
+    // cache.invalidateDeferred(...) calls made during message handling are
+    // buffered and fired the next time the cache is read (via getOrFetch)
+    // OR when this scope ends — whichever comes first. Both branches happen
+    // after any embedded $transaction has committed, so concurrent readers
+    // never repopulate cache from pre-commit DB state.
+    //
+    // Without this scope, invalidateDeferred would fall back to immediate
+    // invalidation, which is fine for handlers whose Prisma writes auto-commit
+    // per statement but unsafe for any path that wraps writes in $transaction.
+    const result = await this.cache.runInScope(() =>
+      this.distributedLockService.withRetryLock(
+        lockKey,
+        () => this.handleMessage(server, socket, kind, payload),
+        5,
+        1000,
+        5000,
+      ),
     );
 
     const duration = Date.now() - startTime;

--- a/apps/server/src/web-socket/v2/web-socket-v2-message-handler.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2-message-handler.ts
@@ -166,7 +166,7 @@ export class WebSocketV2MessageHandler {
 
     // runInScope establishes a per-message AsyncLocalStorage context so any
     // cache.invalidateDeferred(...) calls made during message handling are
-    // buffered and fired the next time the cache is read (via getOrFetch)
+    // buffered and fired the next time the cache is read (via get)
     // OR when this scope ends — whichever comes first. Both branches happen
     // after any embedded $transaction has committed, so concurrent readers
     // never repopulate cache from pre-commit DB state.

--- a/apps/server/src/web-socket/v2/web-socket-v2.service.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2.service.ts
@@ -32,7 +32,6 @@ import {
   BizEvents,
   ClientCondition,
   CustomContentSession,
-  BizAttributeTypes,
 } from '@usertour/types';
 import { WebSocketContext } from './web-socket-v2.dto';
 import { Socket, Server } from 'socket.io';
@@ -43,20 +42,7 @@ import { ContentOrchestratorService } from '@/web-socket/core/content-orchestrat
 import { ProjectCacheService } from '@/shared/project-cache.service';
 import { buildExternalUserRoomId } from '@/utils/websocket-utils';
 import { assignClientContext } from '@/utils/event-v2';
-import { AttributeBizType } from '@/attributes/models/attribute.model';
-import { getAttributeType, isNull, isValidISO8601 } from '@usertour/helpers';
-
-/**
- * Humanize a codeName into a display name.
- * Splits on `_`, `-`, `.` and spaces, capitalizes each word.
- */
-function humanize(name: string): string {
-  return name
-    .split(/[_\-.\s]+/)
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(' ');
-}
+import { humanize } from '@usertour/helpers';
 
 @Injectable()
 export class WebSocketV2Service {
@@ -449,67 +435,17 @@ export class WebSocketV2Service {
         });
       }
 
-      // 2. Process attributes: auto-create Attribute + AttributeOnEvent
-      const eventData: Record<string, any> = {};
+      // 2. Resolve attributes + link them to this Event (handled by BizService).
       const mergedAttributes = assignClientContext(attributes ?? {}, clientContext);
-
-      if (Object.keys(mergedAttributes).length > 0) {
-        for (const attrName of Object.keys(mergedAttributes)) {
-          const attrValue = mergedAttributes[attrName];
-
-          if (isNull(attrValue)) {
-            eventData[attrName] = null;
-            continue;
-          }
-
-          const dataType = getAttributeType(attrValue);
-
-          // Find or create the attribute
-          let attr = await tx.attribute.findFirst({
-            where: { codeName: attrName, projectId, bizType: AttributeBizType.EVENT },
-          });
-
-          if (!attr) {
-            attr = await tx.attribute.create({
-              data: {
-                codeName: attrName,
-                dataType,
-                displayName: humanize(attrName),
-                projectId,
-                bizType: AttributeBizType.EVENT,
-              },
-            });
-            createdNewAttribute = true;
-          }
-
-          // Validate and store value (same logic as insertBizAttributes)
-          if (attr.dataType === BizAttributeTypes.DateTime) {
-            if (!isValidISO8601(attrValue)) {
-              this.logger.error(
-                `Invalid DateTime format for attribute "${attrName}". Received: ${JSON.stringify(attrValue)}. Skipping.`,
-              );
-              continue;
-            }
-            eventData[attrName] = attrValue;
-          } else if (attr.dataType === dataType) {
-            eventData[attrName] = attrValue;
-          } else {
-            this.logger.warn(
-              `Type mismatch for attribute ${attrName}. Expected: ${attr.dataType}, got: ${dataType}`,
-            );
-            continue;
-          }
-
-          // Link attribute to event via AttributeOnEvent
-          const existing = await tx.attributeOnEvent.findFirst({
-            where: { eventId: event.id, attributeId: attr.id },
-          });
-          if (!existing) {
-            await tx.attributeOnEvent.create({
-              data: { eventId: event.id, attributeId: attr.id },
-            });
-          }
-        }
+      const { eventData, createdNewAttribute: ca } =
+        await this.bizService.resolveAndLinkEventAttributes(
+          tx,
+          projectId,
+          event.id,
+          mergedAttributes,
+        );
+      if (ca) {
+        createdNewAttribute = true;
       }
 
       // 3. Create BizEvent

--- a/apps/server/src/web-socket/v2/web-socket-v2.service.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2.service.ts
@@ -40,6 +40,7 @@ import { SocketDataService } from '../core/socket-data.service';
 import { ContentCancelContext, ContentStartContext, SocketData } from '@/common/types/content';
 import { EventTrackingService } from '@/web-socket/core/event-tracking.service';
 import { ContentOrchestratorService } from '@/web-socket/core/content-orchestrator.service';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 import { buildExternalUserRoomId } from '@/utils/websocket-utils';
 import { assignClientContext } from '@/utils/event-v2';
 import { AttributeBizType } from '@/attributes/models/attribute.model';
@@ -67,6 +68,7 @@ export class WebSocketV2Service {
     private eventTrackingService: EventTrackingService,
     private readonly contentOrchestratorService: ContentOrchestratorService,
     private readonly socketDataService: SocketDataService,
+    private readonly cache: ProjectCacheService,
   ) {}
 
   // ============================================================================
@@ -428,6 +430,7 @@ export class WebSocketV2Service {
 
     const { name, attributes, userOnly } = trackEventDto;
 
+    let createdNewAttribute = false;
     const success = await this.prisma.$transaction(async (tx) => {
       // 1. Find or create Event by codeName + projectId
       let event = await tx.event.findFirst({
@@ -476,6 +479,7 @@ export class WebSocketV2Service {
                 bizType: AttributeBizType.EVENT,
               },
             });
+            createdNewAttribute = true;
           }
 
           // Validate and store value (same logic as insertBizAttributes)
@@ -526,6 +530,10 @@ export class WebSocketV2Service {
 
     if (!success) {
       return false;
+    }
+
+    if (createdNewAttribute) {
+      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
     }
 
     await this.contentOrchestratorService.toggleContents(context);

--- a/apps/server/src/web-socket/v2/web-socket-v2.service.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2.service.ts
@@ -416,7 +416,6 @@ export class WebSocketV2Service {
 
     const { name, attributes, userOnly } = trackEventDto;
 
-    let createdNewAttribute = false;
     const success = await this.prisma.$transaction(async (tx) => {
       // 1. Find or create Event by codeName + projectId
       let event = await tx.event.findFirst({
@@ -435,18 +434,16 @@ export class WebSocketV2Service {
         });
       }
 
-      // 2. Resolve attributes + link them to this Event (handled by BizService).
+      // 2. Resolve attributes + link them to this Event (handled by BizService,
+      //    which also takes care of invalidating the project's Attribute cache
+      //    when a new row was auto-created).
       const mergedAttributes = assignClientContext(attributes ?? {}, clientContext);
-      const { eventData, createdNewAttribute: ca } =
-        await this.bizService.resolveAndLinkEventAttributes(
-          tx,
-          projectId,
-          event.id,
-          mergedAttributes,
-        );
-      if (ca) {
-        createdNewAttribute = true;
-      }
+      const eventData = await this.bizService.resolveAndLinkEventAttributes(
+        tx,
+        projectId,
+        event.id,
+        mergedAttributes,
+      );
 
       // 3. Create BizEvent
       await tx.bizEvent.create({
@@ -466,10 +463,6 @@ export class WebSocketV2Service {
 
     if (!success) {
       return false;
-    }
-
-    if (createdNewAttribute) {
-      this.cache.invalidateDeferred(this.cache.keys.attrs(projectId));
     }
 
     await this.contentOrchestratorService.toggleContents(context);

--- a/apps/server/src/web-socket/web-socket.gateway.ts
+++ b/apps/server/src/web-socket/web-socket.gateway.ts
@@ -130,23 +130,4 @@ export class WebSocketGateway {
   ): Promise<GetProjectSettingsResponse> {
     return await this.service.getProjectSettings(body, environment);
   }
-
-  /**
-   * Send content change notification to all users in an environment
-   */
-  async notifyContentChanged(environmentId: string): Promise<void> {
-    try {
-      if (!this.server) {
-        this.logger.warn('Server instance not available');
-        return;
-      }
-
-      this.server.to(`environment:${environmentId}`).emit('content-changed', {
-        timestamp: new Date(),
-      });
-      this.logger.log(`Content change notification sent to environment ${environmentId}`);
-    } catch (error) {
-      this.logger.error(`Failed to send content change notification: ${error.message}`);
-    }
-  }
 }

--- a/packages/helpers/src/attribute.ts
+++ b/packages/helpers/src/attribute.ts
@@ -79,6 +79,18 @@ export const capitalizeFirstLetter = (string: string) => {
   return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
+/**
+ * Humanize a codeName into a display name.
+ * Splits on `_`, `-`, `.` and whitespace, then title-cases each word.
+ */
+export const humanize = (name: string): string => {
+  return name
+    .split(/[_\-.\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+};
+
 export const filterNullAttributes = (attributes: Record<string, any>) => {
   const attrs: Record<string, any> = {};
   for (const key in attributes) {


### PR DESCRIPTION
  ## Summary
  - Project-scoped Redis cache for SDK runtime hot path: Attributes, Themes,
    published Contents per env+type, published Version+Steps, publishedVersionId
  - Per-request ALS memo for BizUser / BizCompany / BizUserOnCompany /
    projectConfig — coalesces fan-out within one client-message
  - Attribute batch lookup refactor (N+1 → single IN query) inside biz.service
  - Cache-coherence fixes around Content writes (multi-env sweep,
    versionFull invalidation on unpublish)
