### PR TITLE
perf(server): pre-fetch toggleContents sessions, expand ALS memo coverage

### DIFF
--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -3,6 +3,9 @@ import { ContentDataType } from '@usertour/types';
 import { RedisService } from './redis.service';
 import { createRequestContext, requestContext } from './request-context';
 
+const MEMO_VALUE = Symbol('memoSetValue');
+type MemoizedPromise<T> = Promise<T> & { [MEMO_VALUE]?: T };
+
 /**
  * Centralized cache for project-scoped configuration data that the SDK
  * websocket message handlers read on every toggleContents iteration but
@@ -107,6 +110,12 @@ export class ProjectCacheService {
     /** MANUAL-segment membership lookup for a given company. */
     bizCompanyOnSegment: (segmentId: string, bizCompanyId: string) =>
       `bizCompanyOnSegment:${segmentId}:${bizCompanyId}`,
+    /**
+     * Pre-fetched union of session/event data for all contentIds visible
+     * in a toggleContents pass. Populated once at scope entry; per-type
+     * findSessions calls peek this and return a contentId-subset view.
+     */
+    toggleSessions: (bizUserId: string) => `toggleSessions:${bizUserId}`,
   };
 
   /**
@@ -301,6 +310,46 @@ export class ProjectCacheService {
       return;
     }
     ctx.memo.delete(key);
+  }
+
+  /**
+   * Pre-populate a per-request memo entry with an already-computed value.
+   * Useful for "fan-out collapse" patterns where the caller resolved the
+   * full result by union once and wants subsequent narrower lookups to
+   * read a subset of that value instead of re-querying.
+   *
+   * Stores the value both as a resolved Promise (for `memoize` callers
+   * that `await` it) and as a synchronous side-channel (for `peekMemo`
+   * callers that need to branch without awaiting).
+   *
+   * No-op when called outside a request scope.
+   */
+  memoSet<T>(key: string, value: T): void {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      return;
+    }
+    const wrapped = Promise.resolve(value) as MemoizedPromise<T>;
+    wrapped[MEMO_VALUE] = value;
+    ctx.memo.set(key, wrapped);
+  }
+
+  /**
+   * Synchronous peek into a memo entry seeded via `memoSet`. Returns
+   * undefined for both "no entry" and "entry seeded asynchronously by
+   * `memoize`" — async-loaded promises don't expose their resolved value
+   * synchronously, so peekMemo cannot read them. Callers that need an
+   * async-loaded value should `await memoize(...)` instead.
+   *
+   * Returns undefined outside a request scope.
+   */
+  peekMemo<T>(key: string): T | undefined {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      return undefined;
+    }
+    const entry = ctx.memo.get(key) as MemoizedPromise<T> | undefined;
+    return entry?.[MEMO_VALUE];
   }
 
   /**

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -64,8 +64,6 @@ export class ProjectCacheService {
     contents: (envId: string, type: string) => `env:${envId}:contents:${type}`,
     /** Full Version row including steps for a specific version id. */
     versionFull: (versionId: string) => `version:${versionId}:full`,
-    /** Single Segment definition by id. */
-    segment: (segmentId: string) => `segment:${segmentId}`,
     /** Map a (env, content) → publishedVersionId so the join doesn't re-run. */
     publishedVersionId: (envId: string, contentId: string) =>
       `env:${envId}:content:${contentId}:pubver`,
@@ -100,6 +98,15 @@ export class ProjectCacheService {
      * `invalidateMemo` after every Redis write.
      */
     socketData: (socketId: string) => `socketData:${socketId}`,
+    /** Single Segment row by id; the same segment is referenced by many
+     * conditions in one EndBatch evaluation. */
+    segment: (segmentId: string) => `segment:${segmentId}`,
+    /** MANUAL-segment membership lookup for a given user. */
+    bizUserOnSegment: (segmentId: string, bizUserId: string) =>
+      `bizUserOnSegment:${segmentId}:${bizUserId}`,
+    /** MANUAL-segment membership lookup for a given company. */
+    bizCompanyOnSegment: (segmentId: string, bizCompanyId: string) =>
+      `bizCompanyOnSegment:${segmentId}:${bizCompanyId}`,
   };
 
   /**

--- a/apps/server/src/shared/project-cache.service.ts
+++ b/apps/server/src/shared/project-cache.service.ts
@@ -93,6 +93,13 @@ export class ProjectCacheService {
     bizUserOnCompanyWithBizCompany: (bizUserId: string, envId: string, externalCompanyId: string) =>
       `bizUserOnCompanyWithBizCompany:${bizUserId}:${envId}:${externalCompanyId}`,
     projectConfig: (projectId: string) => `projectConfig:${projectId}`,
+    /**
+     * Snapshot of the Redis-backed SocketData for a connected client.
+     * Unlike the other memo keys this entry IS mutated mid-scope (session
+     * lifecycle writes), so SocketDataService.set/delete must call
+     * `invalidateMemo` after every Redis write.
+     */
+    socketData: (socketId: string) => `socketData:${socketId}`,
   };
 
   /**
@@ -270,6 +277,23 @@ export class ProjectCacheService {
     const promise = loader();
     ctx.memo.set(key, promise);
     return promise;
+  }
+
+  /**
+   * Drop a per-request memo entry so the next `memoize` for the same key
+   * re-runs its loader. Reserved for state that legitimately mutates inside
+   * a scope (e.g. SocketData session lifecycle writes). For snapshot-style
+   * entities like BizUser this is a code smell — refactor the writer to
+   * keep the snapshot consistent instead.
+   *
+   * No-op when called outside a request scope.
+   */
+  invalidateMemo(key: string): void {
+    const ctx = requestContext.getStore();
+    if (!ctx) {
+      return;
+    }
+    ctx.memo.delete(key);
   }
 
   /**

--- a/apps/server/src/web-socket/core/condition-evaluation.service.ts
+++ b/apps/server/src/web-socket/core/condition-evaluation.service.ts
@@ -419,9 +419,13 @@ export class ConditionEvaluationService {
         return logic === 'is';
       }
       case SegmentDataType.MANUAL: {
-        const userOnSegment = await this.prisma.bizUserOnSegment.findFirst({
-          where: { segmentId: segment.id, bizUserId: context.bizUser.id },
-        });
+        const userOnSegment = await this.cache.memoize(
+          this.cache.memoKeys.bizUserOnSegment(segment.id, context.bizUser.id),
+          () =>
+            this.prisma.bizUserOnSegment.findFirst({
+              where: { segmentId: segment.id, bizUserId: context.bizUser.id },
+            }),
+        );
         return this.applySegmentLogic(logic, !!userOnSegment);
       }
       case SegmentDataType.CONDITION: {
@@ -475,9 +479,13 @@ export class ConditionEvaluationService {
         return logic === 'is';
       }
       case SegmentDataType.MANUAL: {
-        const companyOnSegment = await this.prisma.bizCompanyOnSegment.findFirst({
-          where: { segmentId: segment.id, bizCompanyId: bizCompany.id },
-        });
+        const companyOnSegment = await this.cache.memoize(
+          this.cache.memoKeys.bizCompanyOnSegment(segment.id, bizCompany.id),
+          () =>
+            this.prisma.bizCompanyOnSegment.findFirst({
+              where: { segmentId: segment.id, bizCompanyId: bizCompany.id },
+            }),
+        );
         return this.applySegmentLogic(logic, !!companyOnSegment);
       }
       case SegmentDataType.CONDITION: {
@@ -699,14 +707,16 @@ export class ConditionEvaluationService {
   // ============================================================================
 
   /**
-   * Find segment by ID
-   * @param segmentId - The segment ID
-   * @returns The segment or null if not found
+   * Find segment by ID, memoized per request scope. Same segment id can be
+   * referenced by multiple version conditions across the 6-type
+   * toggleContents loop; without memo each evaluation reissues findFirst.
    */
   private async findSegmentById(segmentId: string) {
-    return await this.prisma.segment.findFirst({
-      where: { id: segmentId },
-    });
+    return this.cache.memoize(this.cache.memoKeys.segment(segmentId), () =>
+      this.prisma.segment.findFirst({
+        where: { id: segmentId },
+      }),
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -346,8 +346,11 @@ export class ContentDataService {
    * mutates Attribute rows (handled by AttributesService write path).
    * Attribute has Date columns but none of the hot-path consumers read
    * them, so caching the entity as-is is safe.
+   *
+   * Public so SessionBuilderService can reuse the same cache instead of
+   * re-querying USER/COMPANY/MEMBERSHIP attributes per session via Prisma.
    */
-  private async findAttributes(environment: Environment): Promise<Attribute[]> {
+  async findAttributes(environment: Environment): Promise<Attribute[]> {
     return await this.cache.get(
       this.cache.keys.attrs(environment.projectId),
       ContentDataService.PROJECT_CONFIG_TTL_SECONDS,

--- a/apps/server/src/web-socket/core/content-data.service.ts
+++ b/apps/server/src/web-socket/core/content-data.service.ts
@@ -39,9 +39,19 @@ import { ProjectCacheService } from '@/shared/project-cache.service';
 // ============================================================================
 
 /**
+ * Sentinel returned by `findSessions` for contentIds the caller asked
+ * about that aren't present in a pre-fetched union map. Same shape the
+ * DB path would have produced for a content with zero sessions / events.
+ */
+const EMPTY_SESSION_COLLECTION: ContentSessionCollection = {
+  totalSessions: 0,
+  completedSessions: 0,
+};
+
+/**
  * Context for content queries containing essential parameters
  */
-interface ContentQueryContext {
+export interface ContentQueryContext {
   readonly environment: Environment;
   readonly externalUserId: string;
   readonly externalCompanyId?: string;
@@ -178,6 +188,65 @@ export class ContentDataService {
       });
       return [];
     }
+  }
+
+  /**
+   * Pre-fetch the union of session/event data for every contentId visible
+   * to a toggleContents pass and stash it on the request memo.
+   *
+   * Background — `toggleContents` walks the 6 ContentDataType values in a
+   * for-loop. Each iteration calls `findSessions(contentIds, bizUserId)`
+   * which fans out into 4 sub-queries (1 findMany + 2 groupBy + 1 bizEvent
+   * findMany). Per-type contentId sets are disjoint, so naively that's
+   * 4 × 6 ≈ 24 round-trips for read-only data we could have batched.
+   *
+   * This method runs the same 4 sub-queries ONCE over the union of all
+   * per-type contentIds, then writes the resulting Map into the request
+   * memo. Per-type `findSessions` calls peek the memo and return a
+   * subset view; on miss they fall through to the original full-query
+   * path so this method is purely opportunistic — handlers that don't
+   * call it (or scopes that aren't active) keep working unchanged.
+   *
+   * Sequencing constraint: `handleChecklistCompletedEvents` MUST run
+   * before this method on each toggleContents pass — it tracks
+   * CHECKLIST_COMPLETED events that flip session state, and pre-fetching
+   * before those events fire would snapshot pre-completion sessions and
+   * mask just-fired events from per-type evaluation.
+   *
+   * Mid-loop `createBizSession` calls do NOT need to invalidate the
+   * memo: per-type contentIds are disjoint, so a session created for
+   * type A's contentId is never read again by type B's findSessions.
+   * `hasAvailableSession` / `hasBizEvent` deliberately bypass this memo
+   * (see hasBizEvent above) for the cross-type cases where this
+   * disjointness assumption breaks.
+   */
+  async prefetchToggleContentSessions(
+    queryContext: ContentQueryContext,
+    contentTypes: ContentDataType[],
+  ): Promise<void> {
+    const { environment, externalUserId } = queryContext;
+
+    // Resolve bizUser + per-type version slices in parallel. findVersions
+    // is already cache-backed for single-type calls, so this is mostly
+    // Redis GETs.
+    const [bizUser, ...versionsByType] = await Promise.all([
+      this.findBizUser(environment, externalUserId),
+      ...contentTypes.map((type) => this.findVersions(environment, [type])),
+    ]);
+    if (!bizUser) {
+      return;
+    }
+
+    const unionContentIds = [
+      ...new Set(versionsByType.flat().map((version) => version.content.id)),
+    ];
+    if (unionContentIds.length === 0) {
+      return;
+    }
+
+    // Bypass the memo on this single canonical fetch — we ARE the writer.
+    const fullMap = await this.findSessionsFromDB(unionContentIds, bizUser.id);
+    this.cache.memoSet(this.cache.memoKeys.toggleSessions(bizUser.id), fullMap);
   }
 
   /**
@@ -524,9 +593,42 @@ export class ContentDataService {
   }
 
   /**
-   * Find session statistics for multiple contents
+   * Find session statistics for multiple contents.
+   *
+   * Reads from the request-scoped union memo when available
+   * (populated by `prefetchToggleContentSessions`) to collapse the
+   * per-type fan-out in toggleContents to one DB batch. Falls through
+   * to the full 4-query path when no prefetched union exists — keeps
+   * callers outside the toggleContents pre-fetch path working unchanged.
    */
   private async findSessions(
+    contentIds: string[],
+    bizUserId: string,
+  ): Promise<Map<string, ContentSessionCollection>> {
+    const prefetched = this.cache.peekMemo<Map<string, ContentSessionCollection>>(
+      this.cache.memoKeys.toggleSessions(bizUserId),
+    );
+    // Only short-circuit if every requested contentId was part of the
+    // pre-fetched union. The explicit-versionId path in findVersions is
+    // env-agnostic and can surface contents that prefetch's published-only
+    // walk skipped — falling through to the DB then is correct AND keeps
+    // the prefetch optimization purely opportunistic.
+    if (prefetched && contentIds.every((id) => prefetched.has(id))) {
+      const subset = new Map<string, ContentSessionCollection>();
+      for (const contentId of contentIds) {
+        subset.set(contentId, prefetched.get(contentId) ?? EMPTY_SESSION_COLLECTION);
+      }
+      return subset;
+    }
+    return this.findSessionsFromDB(contentIds, bizUserId);
+  }
+
+  /**
+   * Original 4-query session/event fan-out. Always hits the DB; used by
+   * the prefetch entry point and as the fallback for `findSessions`
+   * outside the toggleContents pre-fetch flow.
+   */
+  private async findSessionsFromDB(
     contentIds: string[],
     bizUserId: string,
   ): Promise<Map<string, ContentSessionCollection>> {

--- a/apps/server/src/web-socket/core/content-orchestrator.service.ts
+++ b/apps/server/src/web-socket/core/content-orchestrator.service.ts
@@ -41,6 +41,7 @@ import {
   extractSessionByContentType,
   buildSocketLockKey,
   extractSessionsByContentType,
+  getSocketId,
 } from '@/utils/websocket-utils';
 import {
   SocketData,
@@ -61,6 +62,7 @@ import { SessionBuilderService } from './session-builder.service';
 import { EventTrackingService } from './event-tracking.service';
 import { SocketOperationService } from './socket-operation.service';
 import { SocketDataService } from './socket-data.service';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 import { getStartEventType, getEndEventType } from '@/utils/event-v2';
 import { WebSocketContext } from '../v2/web-socket-v2.dto';
 
@@ -89,6 +91,7 @@ export class ContentOrchestratorService {
     private readonly socketOperationService: SocketOperationService,
     private readonly socketDataService: SocketDataService,
     private readonly distributedLockService: DistributedLockService,
+    private readonly cache: ProjectCacheService,
   ) {}
 
   // ============================================================================
@@ -424,12 +427,15 @@ export class ContentOrchestratorService {
   }
 
   /**
-   * Get socket data from Redis
-   * @param socket - The socket instance
-   * @returns Promise<SocketData | null>
+   * Get socket data from Redis, memoized per request scope so the
+   * 8+ orchestrator reads in one EndBatch coalesce into a single Redis GET.
+   * SocketDataService.set/delete invalidate the memo so post-write reads
+   * return the new state.
    */
   private async getSocketData(socket: Socket): Promise<SocketData | null> {
-    return await this.socketDataService.get(socket);
+    return this.cache.memoize(this.cache.memoKeys.socketData(getSocketId(socket)), () =>
+      this.socketDataService.get(socket),
+    );
   }
 
   /**

--- a/apps/server/src/web-socket/core/content-orchestrator.service.ts
+++ b/apps/server/src/web-socket/core/content-orchestrator.service.ts
@@ -376,9 +376,29 @@ export class ContentOrchestratorService {
       },
     };
 
-    // Handle checklist completed events
+    // Handle checklist completed events. MUST run before the prefetch
+    // below — it tracks CHECKLIST_COMPLETED events that flip session
+    // state, and prefetching first would freeze pre-completion sessions
+    // into the memo and mask just-fired events from per-type evaluation.
     if (contentTypes.some((type) => isSingletonContentType(type))) {
       await this.handleChecklistCompletedEvents(socket);
+    }
+
+    // Pre-fetch the session/event union for every contentId visible across
+    // all six types so the per-type loop below collapses 4×6 sub-queries
+    // down to a single batched fetch. Best-effort: bails out silently
+    // when socket data is gone, leaving findSessions to fall back to its
+    // original DB path.
+    const socketData = await this.getSocketData(socket);
+    if (socketData) {
+      await this.contentDataService.prefetchToggleContentSessions(
+        {
+          environment: socketData.environment,
+          externalUserId: socketData.externalUserId,
+          externalCompanyId: socketData.externalCompanyId,
+        },
+        contentTypes,
+      );
     }
 
     // Start content types sequentially

--- a/apps/server/src/web-socket/core/session-builder.service.ts
+++ b/apps/server/src/web-socket/core/session-builder.service.ts
@@ -790,21 +790,24 @@ export class SessionBuilderService {
       return [];
     }
 
-    const attributes = await this.prisma.attribute.findMany({
-      where: {
-        projectId: environment.projectId,
-        bizType: {
-          in: [AttributeBizType.USER, AttributeBizType.COMPANY, AttributeBizType.MEMBERSHIP],
-        },
-      },
-    });
-
-    // Filter attributes by the extracted IDs and codes
-    const relevantAttributes = attributes.filter(
-      (attr) =>
+    // Reuse the project-level Attribute cache from ContentDataService instead
+    // of issuing a per-session findMany. Cache contains [USER, COMPANY,
+    // MEMBERSHIP, EVENT] across all extracts; filter EVENT out so this
+    // method's contract (session attributes only) is preserved.
+    const allAttributes = await this.contentDataService.findAttributes(environment);
+    const relevantAttributes = allAttributes.filter((attr) => {
+      const isSessionBizType =
+        attr.bizType === AttributeBizType.USER ||
+        attr.bizType === AttributeBizType.COMPANY ||
+        attr.bizType === AttributeBizType.MEMBERSHIP;
+      if (!isSessionBizType) {
+        return false;
+      }
+      return (
         attrIds.includes(attr.id) ||
-        (attrCodes.includes(attr.codeName) && attr.bizType === AttributeBizType.USER),
-    );
+        (attrCodes.includes(attr.codeName) && attr.bizType === AttributeBizType.USER)
+      );
+    });
 
     // Query attribute values and build result
     const results: SessionAttribute[] = [];

--- a/apps/server/src/web-socket/core/socket-data.service.ts
+++ b/apps/server/src/web-socket/core/socket-data.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { RedisService } from '@/shared/redis.service';
+import { ProjectCacheService } from '@/shared/project-cache.service';
 import { SocketData } from '@/common/types/content';
 import { Socket } from 'socket.io';
 import { getSocketId } from '@/utils/websocket-utils';
@@ -17,7 +18,10 @@ export class SocketDataService {
   private readonly logger = new Logger(SocketDataService.name);
   private readonly DEFAULT_TTL_SECONDS = 60 * 60 * 24; // 24 hours
 
-  constructor(private readonly redisService: RedisService) {}
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly cache: ProjectCacheService,
+  ) {}
 
   // ============================================================================
   // Private Helper Methods - Key Management
@@ -69,6 +73,7 @@ export class SocketDataService {
       };
 
       await this.redisService.setex(key, this.DEFAULT_TTL_SECONDS, JSON.stringify(finalData));
+      this.cache.invalidateMemo(this.cache.memoKeys.socketData(socketId));
       this.logger.debug(`Client data set for socket ${socketId}`);
       return true;
     } catch (error) {
@@ -116,6 +121,7 @@ export class SocketDataService {
 
       // Remove socket data
       await client.del(key);
+      this.cache.invalidateMemo(this.cache.memoKeys.socketData(socketId));
 
       this.logger.debug(`Removed socket data for socket ${socketId}`);
       return true;

--- a/apps/server/src/web-socket/v2/web-socket-v2.service.ts
+++ b/apps/server/src/web-socket/v2/web-socket-v2.service.ts
@@ -40,7 +40,7 @@ import { ContentCancelContext, ContentStartContext, SocketData } from '@/common/
 import { EventTrackingService } from '@/web-socket/core/event-tracking.service';
 import { ContentOrchestratorService } from '@/web-socket/core/content-orchestrator.service';
 import { ProjectCacheService } from '@/shared/project-cache.service';
-import { buildExternalUserRoomId } from '@/utils/websocket-utils';
+import { buildExternalUserRoomId, getSocketId } from '@/utils/websocket-utils';
 import { assignClientContext } from '@/utils/event-v2';
 import { humanize } from '@usertour/helpers';
 
@@ -62,12 +62,15 @@ export class WebSocketV2Service {
   // ============================================================================
 
   /**
-   * Get socket data from Redis
-   * @param socket - The socket instance
-   * @returns Promise<SocketData | null>
+   * Get socket data from Redis, memoized per request scope so the
+   * 8+ orchestrator reads in one EndBatch coalesce into a single Redis GET.
+   * SocketDataService.set/delete invalidate the memo so post-write reads
+   * return the new state.
    */
   async getSocketData(socket: Socket): Promise<SocketData | null> {
-    return await this.socketDataService.get(socket);
+    return this.cache.memoize(this.cache.memoKeys.socketData(getSocketId(socket)), () =>
+      this.socketDataService.get(socket),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
  - B1: collapse 6× per-type findSessions fan-out into one union pre-fetch
  - A1: memoize SocketData per request scope (orchestrator reads coalesce)
  - A2: reuse cached Attribute table in session builder
  - A4+A5: memoize segment / bizUserOnSegment / bizCompanyOnSegment lookups
