### PR TITLE
fix(theme-builder): block Viewer-role users from editing themes

### DIFF
--- a/apps/web/src/pages/settings/themes/components/theme-builder/theme-builder.tsx
+++ b/apps/web/src/pages/settings/themes/components/theme-builder/theme-builder.tsx
@@ -1,3 +1,4 @@
+import { useAppContext } from '@/contexts/app-context';
 import { useAttributeListContext } from '@/contexts/attribute-list-context';
 import { StorageKeys } from '@usertour-packages/constants';
 import { validateConditions } from '@usertour-packages/shared-components';
@@ -45,6 +46,12 @@ export function ThemeBuilder({ theme, onSave, onRename, onActionComplete }: Prop
   const [activeVariationId, setActiveVariationId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
 
+  const { isViewOnly } = useAppContext();
+  // Read-only when the theme itself is a system preset OR when the
+  // current viewer holds the Viewer role. Both gate every write surface
+  // (setField, save, rename, variation add/remove/reorder).
+  const isReadOnly = !!theme.isSystem || isViewOnly;
+
   const initialBase = useMemo(() => mergeWithDefaults(theme.settings), [theme.settings]);
   const initialVariations = useMemo(() => theme.variations ?? [], [theme.variations]);
 
@@ -60,10 +67,10 @@ export function ThemeBuilder({ theme, onSave, onRename, onActionComplete }: Prop
   }, []);
 
   const onAddVariation = useCallback(() => {
-    if (theme.isSystem) return;
+    if (isReadOnly) return;
     const id = draft.addVariation();
     setActiveVariationId(id);
-  }, [draft, theme.isSystem]);
+  }, [draft, isReadOnly]);
 
   const onDeleteVariation = useCallback(
     (id: string) => {
@@ -143,9 +150,9 @@ export function ThemeBuilder({ theme, onSave, onRename, onActionComplete }: Prop
       finalSettings: draft.finalSettings,
       getField: draft.getField,
       setField: draft.setField,
-      isReadOnly: !!theme.isSystem,
+      isReadOnly,
     }),
-    [draft.activeSettings, draft.finalSettings, draft.getField, draft.setField, theme.isSystem],
+    [draft.activeSettings, draft.finalSettings, draft.getField, draft.setField, isReadOnly],
   );
 
   return (
@@ -161,6 +168,8 @@ export function ThemeBuilder({ theme, onSave, onRename, onActionComplete }: Prop
           hasUnsavedChanges={draft.hasUnsavedChanges}
           isSaving={isSaving}
           onSave={handleSave}
+          isReadOnly={isReadOnly}
+          isViewOnly={isViewOnly}
         />
         <div className="flex flex-1 overflow-hidden">
           <VariationsSidebar
@@ -177,7 +186,7 @@ export function ThemeBuilder({ theme, onSave, onRename, onActionComplete }: Prop
               }
             }}
             onReorder={draft.reorderVariations}
-            disabled={theme.isSystem}
+            disabled={isReadOnly}
             width={leftResizable.width}
             resize={{
               isAtMin: leftResizable.isAtMin,

--- a/apps/web/src/pages/settings/themes/components/theme-builder/top-bar/top-bar.tsx
+++ b/apps/web/src/pages/settings/themes/components/theme-builder/top-bar/top-bar.tsx
@@ -21,6 +21,17 @@ interface Props {
   hasUnsavedChanges: boolean;
   isSaving: boolean;
   onSave: () => void;
+  // Covers both system-preset themes and Viewer-role users. Used to gate
+  // rename + save; the System pill below still reads only `theme.isSystem`
+  // because that badge specifically signals "this is a preset", not "you
+  // can't write".
+  isReadOnly: boolean;
+  // Viewer-role gate, used to disable the actions dropdown (Duplicate /
+  // Delete / Set-as-default). Distinct from `isReadOnly` because a system
+  // theme should still expose the dropdown so non-Viewer users can
+  // Duplicate it — only Viewers lose the menu entirely. Mirrors the
+  // ThemeEditDropdownMenu `disabled` prop usage in theme-list-preview.
+  isViewOnly: boolean;
 }
 
 export function TopBar({
@@ -30,6 +41,8 @@ export function TopBar({
   hasUnsavedChanges,
   isSaving,
   onSave,
+  isReadOnly,
+  isViewOnly,
 }: Props) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -56,7 +69,7 @@ export function TopBar({
         </button>
         <RiArrowRightSLine className="h-4 w-4 shrink-0 text-muted-foreground/60" />
         <div className="flex min-w-0 items-center gap-2">
-          <EditableTitle value={theme.name} onRename={onRename} disabled={theme.isSystem} />
+          <EditableTitle value={theme.name} onRename={onRename} disabled={isReadOnly} />
           {theme.isSystem && (
             // Same shape as the System badges on Events / Attributes lists
             // (shield + sentence-case label, secondary muted surface) so users
@@ -94,9 +107,9 @@ export function TopBar({
           hasUnsavedChanges={hasUnsavedChanges}
           isSaving={isSaving}
           onSave={onSave}
-          disabled={theme.isSystem}
+          disabled={isReadOnly}
         />
-        <ThemeEditDropdownMenu theme={theme} onSubmit={onActionComplete}>
+        <ThemeEditDropdownMenu theme={theme} onSubmit={onActionComplete} disabled={isViewOnly}>
           <MoreButton aria-label={t('themeBuilder.aria.themeActions')} />
         </ThemeEditDropdownMenu>
       </div>


### PR DESCRIPTION
The builder's read-only guard only checked `theme.isSystem`, so a Viewer-role user could open any non-system theme, change settings, rename it, save, add variations, and use the actions dropdown — the server would reject the writes but the UI happily accepted them.

Pull `isViewOnly` from the app context and treat write surfaces as two separate concerns:

  * `isReadOnly = theme.isSystem || isViewOnly` — gates the actual theme contents (setField, save, rename, variation add / delete / reorder).
  * `isViewOnly` alone — gates the right-cluster actions dropdown (Duplicate / Delete / Set as default). Kept distinct so Admins viewing a *system* theme keep their Duplicate entry point, which is the canonical "make this preset editable" flow.

Mirrors how `theme-list-preview.tsx` already used `isViewOnly` on the same dropdown, just on the list page.