### PR TITLE
chore(sdk): bump version to 0.7.0

### DIFF
--- a/apps/sdk/package.json
+++ b/apps/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usertour/sdk",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "type": "module",
   "homepage": "https://www.usertour.io",
   "author": "Usertour, Inc.",


### PR DESCRIPTION
The namespace unification changes every @usertour-packages/* import path that SDK consumers transitively touch, so bump the minor to signal the break.