### PR TITLE
refactor(web): single-source globalConfig on guarded auth pages

### DIFF
--- a/apps/web/src/pages/authentication/components/sign-up-link.tsx
+++ b/apps/web/src/pages/authentication/components/sign-up-link.tsx
@@ -1,6 +1,6 @@
-import { useGlobalConfigQuery } from '@usertour/hooks';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useAppContext } from '@/contexts/app-context';
 
 interface SignUpPromptProps {
   prefix?: string;
@@ -14,9 +14,17 @@ export const SignUpPrompt = ({
   className = 'text-center text-sm text-muted-foreground',
 }: SignUpPromptProps) => {
   const { t } = useTranslation('ui');
-  const { data, loading } = useGlobalConfigQuery();
+  // Read globalConfig from AppContext (single source) instead of a second
+  // query, so this renders in lockstep with the card. The `!globalConfig`
+  // guard keeps the old "don't show until config is known" safety for any
+  // surface not already gated by AuthGuard.
+  const { globalConfig } = useAppContext();
 
-  if (loading || data?.allowUserRegistration === false || data?.needsSystemAdminSetup === true) {
+  if (
+    !globalConfig ||
+    globalConfig.allowUserRegistration === false ||
+    globalConfig.needsSystemAdminSetup === true
+  ) {
     return null;
   }
 

--- a/apps/web/src/pages/authentication/setup-admin.tsx
+++ b/apps/web/src/pages/authentication/setup-admin.tsx
@@ -6,16 +6,19 @@ import { SpinnerIcon } from '@usertour/icons';
 import { Input } from '@usertour/input';
 import { useToast } from '@usertour/use-toast';
 import { getErrorMessage } from '@usertour/helpers';
-import { useGlobalConfigQuery, useSetupSystemAdminMutation } from '@usertour/hooks';
+import { useSetupSystemAdminMutation } from '@usertour/hooks';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 import * as z from 'zod';
+import { useAppContext } from '@/contexts/app-context';
 import { AuthCard } from './components/auth-card';
 
 const SetupAdmin = () => {
   const { t } = useTranslation('ui');
-  const { data: globalConfig, loading: globalConfigLoading } = useGlobalConfigQuery();
+  // globalConfig from AppContext (single source); AuthGuard (mode=setup) already
+  // waited for it before this route renders, so no local loading gate is needed.
+  const { globalConfig } = useAppContext();
   const { invoke, loading } = useSetupSystemAdminMutation();
   const { toast } = useToast();
 
@@ -57,18 +60,8 @@ const SetupAdmin = () => {
     }
   };
 
-  if (!globalConfigLoading && globalConfig?.needsSystemAdminSetup === false) {
+  if (globalConfig?.needsSystemAdminSetup === false) {
     return <Navigate to="/auth/signin" replace />;
-  }
-
-  if (globalConfigLoading) {
-    return (
-      <AuthCard
-        title={t('auth.setupAdmin.title')}
-        description={t('auth.setupAdmin.description')}
-        loading
-      />
-    );
   }
 
   return (

--- a/apps/web/src/pages/authentication/sign-in.tsx
+++ b/apps/web/src/pages/authentication/sign-in.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useGlobalConfigQuery } from '@usertour/hooks';
+import { useAppContext } from '@/contexts/app-context';
 import { AuthCard } from './components/auth-card';
 import { SignInForm } from './components/sign-in-form';
 import { SignUpPrompt } from './components/sign-up-link';
@@ -11,7 +11,10 @@ type View = 'signin' | 'forgot' | 'forgotSuccess';
 
 const SignIn = () => {
   const { t } = useTranslation('ui');
-  const { data: globalConfig, loading: globalConfigLoading } = useGlobalConfigQuery();
+  // globalConfig is read from AppContext, not a second query: AuthGuard already
+  // blocks this route until globalConfig has loaded, so it is guaranteed present
+  // here. That makes a local loading gate redundant.
+  const { globalConfig } = useAppContext();
   const [view, setView] = useState<View>('signin');
 
   if (view === 'forgot') {
@@ -31,13 +34,6 @@ const SignIn = () => {
 
   if (view === 'forgotSuccess') {
     return <ResetPasswordSuccess onBack={() => setView('signin')} />;
-  }
-
-  // Defer rendering the real form until globalConfig is known — otherwise
-  // SocialProviders renders OAuth buttons under the "no providers list = all
-  // enabled" default and they disappear once self-host config arrives.
-  if (globalConfigLoading) {
-    return <AuthCard title={t('auth.signIn.title')} loading footer={<SignUpPrompt />} />;
   }
 
   return (

--- a/apps/web/src/pages/authentication/sign-up.tsx
+++ b/apps/web/src/pages/authentication/sign-up.tsx
@@ -10,7 +10,8 @@ import { Input } from '@usertour/input';
 import { getErrorMessage } from '@usertour/helpers';
 import { useToast } from '@usertour/use-toast';
 import { Link } from 'react-router-dom';
-import { useCreateMagicLinkMutation, useGlobalConfigQuery } from '@usertour/hooks';
+import { useCreateMagicLinkMutation } from '@usertour/hooks';
+import { useAppContext } from '@/contexts/app-context';
 import { AuthCard } from './components/auth-card';
 import {
   SignUpSuccess,
@@ -20,7 +21,9 @@ import { SignUpDisabledCard } from './components/sign-up-disabled-card';
 
 export const SignUp = () => {
   const { t } = useTranslation('ui');
-  const { data: globalConfig, loading: globalConfigLoading } = useGlobalConfigQuery();
+  // globalConfig from AppContext (single source); AuthGuard already waited for
+  // it before this guest route renders, so no local loading gate is needed.
+  const { globalConfig } = useAppContext();
   const { invoke: createMagicLink } = useCreateMagicLinkMutation();
   const { toast } = useToast();
   const [registerData, setRegisterData] = useState<SignUpSuccessProps | null>(null);
@@ -55,10 +58,6 @@ export const SignUp = () => {
 
   if (registerData) {
     return <SignUpSuccess {...registerData} />;
-  }
-
-  if (globalConfigLoading) {
-    return <AuthCard title={t('auth.magicLink.title')} loading />;
   }
 
   if (globalConfig?.allowUserRegistration === false) {

--- a/apps/web/src/pages/settings/account/components/account-two-factor-form.tsx
+++ b/apps/web/src/pages/settings/account/components/account-two-factor-form.tsx
@@ -23,7 +23,6 @@ import {
   TwoFactorSetupPayload,
   useConfirmTwoFactorSetupMutation,
   useDisableTwoFactorMutation,
-  useGlobalConfigQuery,
   useRegenerateRecoveryCodesMutation,
   useStartTwoFactorSetupMutation,
 } from '@usertour/hooks';
@@ -46,8 +45,7 @@ const downloadCodes = (codes: string[]) => {
 
 export const AccountTwoFactorForm = () => {
   const { t } = useTranslation('ui');
-  const { userInfo } = useAppContext();
-  const { data: globalConfig } = useGlobalConfigQuery();
+  const { userInfo, globalConfig } = useAppContext();
   const apollo = useApolloClient();
   const { toast } = useToast();
   const disable = useDisableTwoFactorMutation();


### PR DESCRIPTION
sign-in, sign-up, setup-admin, the SignUpPrompt footer and the account 2FA form each ran their own useGlobalConfigQuery and gated on its loading flag. On routes already behind AuthGuard (which blocks until globalConfig has loaded) those gates are redundant: the components mount only after config is cached, so the extra loading branch is effectively dead — yet it still made the footer pop in after the card and added duplicate queries.

Read globalConfig from AppContext (the single source AuthGuard itself uses) and drop the local query and loading gate. SignUpPrompt keeps a `!globalConfig` guard so it stays hidden until config is known on any ungated surface. invite.tsx is intentionally left as-is: it is not behind AuthGuard and must wait on its own invite lookup anyway, so its loading state is legitimate.