### PR TITLE
fix(web): opt 4 AdminProvidersOutlet Context providers into shared cache

### DIFF
--- a/apps/web/src/contexts/attribute-list-context.tsx
+++ b/apps/web/src/contexts/attribute-list-context.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@apollo/client';
 import { listAttributes } from '@usertour/gql';
 import { Attribute } from '@usertour/types';
 import { ReactNode, createContext, useContext } from 'react';
+import { SHARED_CACHE_QUERY_OPTIONS } from '@/apollo/options';
 
 export interface AttributeListProviderProps {
   children?: ReactNode;
@@ -17,8 +18,13 @@ export const AttributeListContext = createContext<AttributeListContextValue | un
 
 export function AttributeListProvider(props: AttributeListProviderProps): JSX.Element {
   const { children, projectId } = props;
+  // SHARED_CACHE_QUERY_OPTIONS so consumers of this provider (activity
+  // feed, content builder, autostart rules) see attribute mutations
+  // — without it the global no-cache default keeps this observable
+  // isolated from useDeleteAttributeMutation's cache.evict.
   const { data, refetch, loading } = useQuery(listAttributes, {
     variables: { projectId: projectId, bizType: 0 },
+    ...SHARED_CACHE_QUERY_OPTIONS,
   });
 
   const attributeList = data?.listAttributes;

--- a/apps/web/src/contexts/environment-list-context.tsx
+++ b/apps/web/src/contexts/environment-list-context.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, createContext, useContext } from 'react';
 import { useGetUserEnvironmentsQuery } from '@usertour/hooks';
 import { Environment } from '@usertour/types';
+import { SHARED_CACHE_QUERY_OPTIONS } from '@/apollo/options';
 
 export interface EnvironmentListProviderProps {
   children?: ReactNode;
@@ -19,8 +20,14 @@ export const EnvironmentListContext = createContext<EnvironmentListContextValue 
 
 export function EnvironmentListProvider(props: EnvironmentListProviderProps): JSX.Element {
   const { children, projectId } = props;
-  const { environmentList, refetch, loading, isRefetching } =
-    useGetUserEnvironmentsQuery(projectId);
+  // SHARED_CACHE_QUERY_OPTIONS so this query participates in the
+  // normalized cache — without it the global no-cache default keeps
+  // this observable isolated, and the env switcher (which reads from
+  // here) wouldn't reflect cache evicts from useDeleteEnvironmentsMutation.
+  const { environmentList, refetch, loading, isRefetching } = useGetUserEnvironmentsQuery(
+    projectId,
+    SHARED_CACHE_QUERY_OPTIONS,
+  );
 
   const value: EnvironmentListContextValue = {
     environmentList,

--- a/apps/web/src/contexts/subscription-context.tsx
+++ b/apps/web/src/contexts/subscription-context.tsx
@@ -6,6 +6,7 @@ import {
   useGetSubscriptionUsageQuery,
 } from '@usertour/hooks';
 import { ReactNode, createContext, useCallback, useContext, useMemo } from 'react';
+import { SHARED_CACHE_QUERY_OPTIONS } from '@/apollo/options';
 
 export interface SubscriptionProviderProps {
   children?: ReactNode;
@@ -37,11 +38,16 @@ export function SubscriptionProvider(props: SubscriptionProviderProps): JSX.Elem
   // Use encapsulated hooks with custom skip logic
   // Skip query if projectId is missing OR subscriptionId is missing
   // This ensures we don't query when we know there's no subscription
+  // SHARED_CACHE_QUERY_OPTIONS on all three queries so content-preview,
+  // content-detail-builder, and any other consumer of this provider see
+  // subscription / config / usage cache updates — without it the global
+  // no-cache default isolates each observable.
   const {
     subscription,
     loading: subscriptionLoading,
     refetch: refetchSubscription,
   } = useGetSubscriptionByProjectIdQuery(projectId, {
+    ...SHARED_CACHE_QUERY_OPTIONS,
     skip: !projectId || !subscriptionId, // Skip if either is missing
   });
 
@@ -50,10 +56,14 @@ export function SubscriptionProvider(props: SubscriptionProviderProps): JSX.Elem
     loading: projectConfigLoading,
     refetch: refetchProjectConfig,
   } = useGetProjectConfigQuery(projectId, {
+    ...SHARED_CACHE_QUERY_OPTIONS,
     skip: !projectId,
   });
 
-  const { usage: currentUsage, loading: usageLoading } = useGetSubscriptionUsageQuery(projectId);
+  const { usage: currentUsage, loading: usageLoading } = useGetSubscriptionUsageQuery(
+    projectId,
+    SHARED_CACHE_QUERY_OPTIONS,
+  );
 
   // Calculate derived values
   const planType: PlanType = subscription?.planType ?? PlanType.HOBBY;

--- a/apps/web/src/contexts/theme-list-context.tsx
+++ b/apps/web/src/contexts/theme-list-context.tsx
@@ -1,6 +1,7 @@
 import { useListThemesQuery } from '@usertour/hooks';
 import { Theme } from '@usertour/types';
 import { ReactNode, createContext, useContext } from 'react';
+import { SHARED_CACHE_QUERY_OPTIONS } from '@/apollo/options';
 
 export interface ThemeListProviderProps {
   children?: ReactNode;
@@ -17,7 +18,13 @@ export const ThemeListContext = createContext<ThemeListContextValue | undefined>
 
 export function ThemeListProvider(props: ThemeListProviderProps): JSX.Element {
   const { children, projectId } = props;
-  const { themeList, refetch, loading, isRefetching } = useListThemesQuery(projectId);
+  // SHARED_CACHE_QUERY_OPTIONS so content-detail-builder's theme picker
+  // reflects useDeleteThemeMutation's cache.evict — without it the global
+  // no-cache default keeps this observable isolated.
+  const { themeList, refetch, loading, isRefetching } = useListThemesQuery(
+    projectId,
+    SHARED_CACHE_QUERY_OPTIONS,
+  );
 
   const value: ThemeListContextValue = {
     themeList,


### PR DESCRIPTION
EnvironmentListProvider / AttributeListProvider / ThemeListProvider / SubscriptionProvider all sit on the global no-cache default for their useQuery calls, which means their ObservableQueries aren't registered as InMemoryCache watches. mutation update(cache) callbacks evict entities + broadcastWatches, but only watchers see the broadcast — these four observables don't, so consumers reading from these contexts keep showing the deleted/stale data.

User-visible regression: deleting an environment from settings/environments removed the row from the settings list (its own query is on SHARED_CACHE_QUERY_OPTIONS), but the env switcher in the admin layout still showed the gone env — admin-env-switcher reads from EnvironmentListProvider, which wasn't watching the cache.

Same shape across all four:
- AttributeListProvider feeds activity-feed, content-detail-builder, content-detail-autostart-rules
- ThemeListProvider feeds content-detail-builder's theme picker
- SubscriptionProvider feeds content-preview / content-detail-builder's shouldShowMadeWith
- EnvironmentListProvider feeds admin-env-switcher, use-environment-selection, use-content-publish-state, the publish/ unpublish forms, and content-detail-builder

Pass SHARED_CACHE_QUERY_OPTIONS to each so the queries participate in the normalized cache and pick up mutation broadcasts.

Verified: typecheck + biome + vite build all green.