### PR TITLE
feat(web): show total-count line on users + companies tables

### DIFF
--- a/apps/web/src/components/segments/entity/entity-config.tsx
+++ b/apps/web/src/components/segments/entity/entity-config.tsx
@@ -67,6 +67,9 @@ export interface EntityI18nKeys {
   // Empty state
   emptyMessage: string;
   emptyDescription: string;
+  // Table footer — total-count line on the pagination row. Takes
+  // `{ count }` interpolation.
+  totalCount: string;
   // Toolbar / row actions
   addToManualSegment: string;
   deleteAction: string; // 'users.actions.deleteUser' / 'companies.actions.deleteCompany'
@@ -149,6 +152,7 @@ export const USER_CONFIG: EntityConfig<BizUser> = {
     editSegmentNameTooltip: 'users.segments.tooltips.editName',
     emptyMessage: 'users.empty.noUsersFound',
     emptyDescription: 'users.empty.noUsersFoundDescription',
+    totalCount: 'users.list.totalCount',
     addToManualSegment: 'users.actions.addToManualSegment',
     deleteAction: 'users.actions.deleteUser',
     removeFromSegment: 'users.actions.removeFromSegment',
@@ -186,6 +190,7 @@ export const COMPANY_CONFIG: EntityConfig<BizCompany> = {
     editSegmentNameTooltip: 'companies.detail.tooltips.editName',
     emptyMessage: 'companies.empty.noCompaniesFound',
     emptyDescription: 'companies.empty.noCompaniesFoundDescription',
+    totalCount: 'companies.list.totalCount',
     addToManualSegment: 'companies.actions.addToManualSegment',
     deleteAction: 'companies.actions.deleteCompany',
     removeFromSegment: 'companies.actions.removeFromSegment',

--- a/apps/web/src/components/segments/entity/entity-data-table.tsx
+++ b/apps/web/src/components/segments/entity/entity-data-table.tsx
@@ -80,6 +80,7 @@ export function EntityDataTable<TRow extends EntityRow>({
     pageCount,
     pagination,
     setPagination,
+    totalCount,
   } = useCursorPagination<TRow, typeof effectiveQuery>({
     query: effectiveQuery,
     useListQuery: config.useListQuery,
@@ -213,7 +214,11 @@ export function EntityDataTable<TRow extends EntityRow>({
         emptyMessage={t(config.i18n.emptyMessage)}
         emptyDescription={t(config.i18n.emptyDescription)}
       />
-      <DataTablePagination table={table} busy={loading || isRefetching} />
+      <DataTablePagination
+        table={table}
+        busy={loading || isRefetching}
+        totalCountText={t(config.i18n.totalCount, { count: totalCount })}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/segments/table/data-table-pagination.tsx
+++ b/apps/web/src/components/segments/table/data-table-pagination.tsx
@@ -6,9 +6,10 @@ const PAGE_SIZE_OPTIONS = [20, 50, 100];
 export function DataTablePagination<TData extends { id: string }>(
   props: DataTablePaginationProps<TData>,
 ) {
-  const { table, busy = false } = props;
+  const { table, busy = false, totalCountText } = props;
   return (
-    <div className="flex items-center justify-end px-2">
+    <div className="flex items-center justify-between px-2">
+      <div className="flex-1 text-sm text-muted-foreground">{totalCountText}</div>
       <CursorPaginationControls table={table} busy={busy} pageSizeOptions={PAGE_SIZE_OPTIONS} />
     </div>
   );

--- a/apps/web/src/components/segments/table/types.ts
+++ b/apps/web/src/components/segments/table/types.ts
@@ -71,6 +71,10 @@ export interface DataTablePaginationProps<TData extends { id: string }> {
    *  reads "Page N+1". Pass `loading || isRefetching` from the
    *  hook's result to gate the buttons until the response lands. */
   busy?: boolean;
+  /** Optional total-count line on the left of the pagination row
+   *  ("11 users in total."). Caller is responsible for i18n —
+   *  `@usertour/ui` primitives don't import `react-i18next`. */
+  totalCountText?: React.ReactNode;
 }
 
 // Column header props interface

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -938,6 +938,9 @@ const translations = {
       noUsersFound: 'No users found',
       noUsersFoundDescription: 'Try adjusting your filters or create new users.',
     },
+    list: {
+      totalCount: '{{count}} users in total.',
+    },
     detail: {
       title: 'User Detail',
       breadcrumb: 'Users',
@@ -1192,6 +1195,9 @@ const translations = {
     empty: {
       noCompaniesFound: 'No companies found',
       noCompaniesFoundDescription: 'Try adjusting your filters or create new companies.',
+    },
+    list: {
+      totalCount: '{{count}} companies in total.',
     },
     detail: {
       title: 'Company Detail',

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -876,6 +876,9 @@ const translations = {
       noUsersFound: '未找到用户',
       noUsersFoundDescription: '请尝试调整筛选条件或创建新用户。',
     },
+    list: {
+      totalCount: '共 {{count}} 个用户。',
+    },
     detail: {
       title: '用户详情',
       breadcrumb: '用户',
@@ -1107,6 +1110,9 @@ const translations = {
     empty: {
       noCompaniesFound: '未找到公司',
       noCompaniesFoundDescription: '请尝试调整筛选条件或创建新公司。',
+    },
+    list: {
+      totalCount: '共 {{count}} 个公司。',
     },
     detail: {
       title: '公司详情',


### PR DESCRIPTION
The analytics sessions table already shows "N sessions in total." on the left of the pagination row; users + companies tables had nothing in that slot. Symmetrise.

- DataTablePagination accepts a `totalCountText?: ReactNode` prop and renders it on the left. Primitive stays i18n-free per the shared-UI doctrine — the consumer composes the localised string and hands it in already-rendered.

- EntityI18nKeys gains a `totalCount` key for users + companies; both configs populate it. EN: "{count} users in total." / "{count} companies in total." — matches the existing sessions copy. zh-Hans: "共 {count} 个用户。" / "共 {count} 个公司。".

- EntityDataTable destructures totalCount from useCursorPagination (was already returned, just not consumed) and passes the t() result to DataTablePagination.