### PR TITLE
fix(web): run useEnvironmentSelection in AdminBuilderLayout

### DIFF
--- a/apps/web/src/pages/layouts/admin-builder-layout.tsx
+++ b/apps/web/src/pages/layouts/admin-builder-layout.tsx
@@ -1,13 +1,24 @@
 import { Outlet } from 'react-router-dom';
+import { useEnvironmentSelection } from '@/hooks/use-environment-selection';
 import { ShellHelmet } from './components/admin-layout';
 
-export const AdminBuilderLayout = () => (
-  <>
-    <ShellHelmet surface="canvas" />
-    <div className="flex-col md:flex">
-      <Outlet />
-    </div>
-  </>
-);
+// Cold-loading the builder URL directly (URL bar / refresh / external
+// link) needs `useEnvironmentSelection` to read `:envId` from the URL
+// and dispatch `setEnvironment` — without it, `AppContext.environment`
+// stays null and `ContentBuilder`'s gate (`!environment` →
+// `<ContentLoading />`) sticks forever. SPA navigations from the
+// detail page were fine because `AdminLayoutContent` already ran the
+// hook; this layout was missed in the original split.
+export const AdminBuilderLayout = () => {
+  useEnvironmentSelection();
+  return (
+    <>
+      <ShellHelmet surface="canvas" />
+      <div className="flex-col md:flex">
+        <Outlet />
+      </div>
+    </>
+  );
+};
 
 AdminBuilderLayout.displayName = 'AdminBuilderLayout';


### PR DESCRIPTION
Cold-loading a builder URL directly (URL bar / refresh / external link) left AppContext.environment as null, sticking ContentBuilder on its loading gate forever. SPA navigations from the detail page worked because AdminLayoutContent already runs the hook; AdminBuilderLayout was missed in the layout split — it renders <Outlet /> directly to keep the full-canvas surface and bypasses AdminLayoutNewContent where the hook is otherwise transitively called.