### PR TITLE
refactor(server): dedup biz GraphQL query where-building (+ doc shado…

### DIFF
--- a/apps/server/src/biz/biz.service.ts
+++ b/apps/server/src/biz/biz.service.ts
@@ -455,54 +455,62 @@ export class BizService {
     return conditions;
   }
 
-  async queryBizUser(query: BizQuery, pagination: PaginationArgs, orderBy: BizOrder) {
-    const { first, last, before, after } = pagination;
+  /**
+   * Build the shared `where` for a biz-user/company GraphQL query: resolves the
+   * environment → projectId, applies segment (MANUAL join or CONDITION filter via
+   * createConditionsFilter), free-text search, and id/membership filters. Returns
+   * null when the environment or a referenced segment is missing (callers map
+   * that to `false`, matching the previous behavior). Extracted so the two query
+   * methods, which were ~90% identical, share one source of truth.
+   */
+  private async buildBizQueryWhere(
+    entity: 'user' | 'company',
+    query: BizQuery,
+  ): Promise<{ environmentId: string; where: Record<string, any> } | null> {
     const { environmentId, segmentId, data, userId, search, companyId } = query;
-    try {
-      const environmenet = await this.prisma.environment.findUnique({
-        where: { id: environmentId },
+    const environment = await this.prisma.environment.findUnique({
+      where: { id: environmentId },
+    });
+    if (!environment) {
+      return null;
+    }
+    const projectId = environment.projectId;
+    const bizType = entity === 'user' ? AttributeBizType.USER : AttributeBizType.COMPANY;
+    const manualSegmentField = entity === 'user' ? 'bizUsersOnSegment' : 'bizCompaniesOnSegment';
+
+    let conditions: any = data ? data : {};
+    let segment: Segment;
+    if (segmentId) {
+      segment = await this.prisma.segment.findFirst({
+        where: { id: segmentId, projectId },
       });
-      if (!environmenet) {
-        return false;
+      if (!segment) {
+        return null;
       }
-      const projectId = environmenet.projectId;
-      let conditions: any = data ? data : {};
-      let segment: Segment;
-      if (segmentId) {
-        segment = await this.prisma.segment.findFirst({
-          where: { id: segmentId, projectId },
-        });
-        if (!segment) {
-          return false;
-        }
-        if (!data && segment.dataType === SegmentDataType.CONDITION) {
-          conditions = segment.data;
-        }
+      if (!data && segment.dataType === SegmentDataType.CONDITION) {
+        conditions = segment.data;
       }
-      const attributes = await this.prisma.attribute.findMany({
-        where: {
-          projectId,
-          bizType: AttributeBizType.USER,
-        },
-      });
-      const filter = createConditionsFilter(conditions, attributes);
-      // const conditions = { ...c };
-      const where: Record<string, any> = filter ? filter : {};
-      if (segment && segment.dataType === SegmentDataType.MANUAL) {
-        where.bizUsersOnSegment = {
-          some: {
-            segment: {
-              id: segment.id,
-            },
+    }
+    const attributes = await this.prisma.attribute.findMany({
+      where: { projectId, bizType },
+    });
+    const filter = createConditionsFilter(conditions, attributes);
+    const where: Record<string, any> = filter ? filter : {};
+    if (segment && segment.dataType === SegmentDataType.MANUAL) {
+      where[manualSegmentField] = {
+        some: {
+          segment: {
+            id: segment.id,
           },
-        };
-      }
+        },
+      };
+    }
+    if (search) {
+      where.OR = this.createSearchConditions(search, attributes, bizType);
+    }
+    if (entity === 'user') {
       if (userId) {
         where.id = userId;
-      }
-      if (search) {
-        // Support searching across multiple fields
-        where.OR = this.createSearchConditions(search, attributes, AttributeBizType.USER);
       }
       if (companyId) {
         where.bizUsersOnCompany = {
@@ -511,7 +519,22 @@ export class BizService {
           },
         };
       }
-      const resp = await findManyCursorConnection(
+    } else if (companyId) {
+      where.id = companyId;
+    }
+
+    return { environmentId, where };
+  }
+
+  async queryBizUser(query: BizQuery, pagination: PaginationArgs, orderBy: BizOrder) {
+    const { first, last, before, after } = pagination;
+    try {
+      const built = await this.buildBizQueryWhere('user', query);
+      if (!built) {
+        return false;
+      }
+      const { environmentId, where } = built;
+      return await findManyCursorConnection(
         (args) =>
           this.prisma.bizUser.findMany({
             where: {
@@ -537,7 +560,6 @@ export class BizService {
           }),
         { first, last, before, after },
       );
-      return resp;
     } catch (error) {
       throw new UnknownError(error);
     }
@@ -545,54 +567,13 @@ export class BizService {
 
   async queryBizCompany(query: BizQuery, pagination: PaginationArgs, orderBy: BizOrder) {
     const { first, last, before, after } = pagination;
-    const { environmentId, segmentId, data, companyId, search } = query;
     try {
-      const environmenet = await this.prisma.environment.findUnique({
-        where: { id: environmentId },
-      });
-      if (!environmenet) {
+      const built = await this.buildBizQueryWhere('company', query);
+      if (!built) {
         return false;
       }
-      const projectId = environmenet.projectId;
-      let conditions: any = data ? data : {};
-      let segment: Segment;
-      if (segmentId) {
-        segment = await this.prisma.segment.findFirst({
-          where: { id: segmentId, projectId },
-        });
-        if (!segment) {
-          return false;
-        }
-        if (!data && segment.dataType === SegmentDataType.CONDITION) {
-          conditions = segment.data;
-        }
-      }
-      const attributes = await this.prisma.attribute.findMany({
-        where: {
-          projectId: environmenet.projectId,
-          bizType: AttributeBizType.COMPANY,
-        },
-      });
-      const filter = createConditionsFilter(conditions, attributes);
-      // const conditions = { ...c };
-      const where: Record<string, any> = filter ? filter : {};
-      if (segment && segment.dataType === SegmentDataType.MANUAL) {
-        where.bizCompaniesOnSegment = {
-          some: {
-            segment: {
-              id: segment.id,
-            },
-          },
-        };
-      }
-      if (companyId) {
-        where.id = companyId;
-      }
-      if (search) {
-        // Support searching across multiple fields for companies
-        where.OR = this.createSearchConditions(search, attributes, AttributeBizType.COMPANY);
-      }
-      const resp = await findManyCursorConnection(
+      const { environmentId, where } = built;
+      return await findManyCursorConnection(
         (args) =>
           this.prisma.bizCompany.findMany({
             where: {
@@ -613,7 +594,6 @@ export class BizService {
           }),
         { first, last, before, after },
       );
-      return resp;
     } catch (error) {
       throw new UnknownError(error);
     }

--- a/apps/server/src/common/openapi/pagination.ts
+++ b/apps/server/src/common/openapi/pagination.ts
@@ -63,7 +63,10 @@ export async function paginate<T>(
   mapResult: (node: T) => any | Promise<any>,
   queryParams?: Record<string, any>,
 ): Promise<PaginationResult<any>> {
-  // Validate limit
+  // Defensive fallback. In practice this is shadowed by the controllers' DTO
+  // validation (`@Min(1)` on the `limit` query param), which the global
+  // ValidationPipe rejects first as E1017 — so a request never reaches here with
+  // limit < 1. Kept as defense-in-depth for any non-HTTP / future caller.
   if (limit < 1) {
     throw new InvalidLimitError();
   }

--- a/apps/server/src/openapi/attribute-definitions/attribute-definitions.service.ts
+++ b/apps/server/src/openapi/attribute-definitions/attribute-definitions.service.ts
@@ -20,6 +20,10 @@ export class OpenAPIAttributeDefinitionsService {
     const projectId = environment.projectId;
     const { limit = 20, scope, cursor, orderBy, eventName } = query;
 
+    // Defensive fallback. The DTO validates `scope` with
+    // `@IsEnum(OpenApiObjectType)`, which the global ValidationPipe rejects first
+    // as E1017 — so an out-of-enum scope never reaches here. Kept as
+    // defense-in-depth for any non-HTTP / future caller.
     if (scope && !isValidOpenApiObjectType(scope)) {
       throw new InvalidScopeError(scope);
     }


### PR DESCRIPTION
…wed checks)

#8 (scoped): queryBizUser and queryBizCompany were ~90% identical. Extract the shared where-building (env→projectId, segment MANUAL/CONDITION via createConditionsFilter, search, id/membership filters) into a private buildBizQueryWhere(entity, query) helper; the two methods become thin wrappers that keep their own (type-correct) findManyCursorConnection wiring. Pure refactor — behavior byte-identical (the where composition is relocated, not changed), verified by biz.e2e (35) and the full e2e suite (685), tsc clean.

Scope note: the cross-surface dedup (queryBizUser ↔ OpenAPI listBizUsersWithRelations) was intentionally NOT done — the methods genuinely differ (companyId internal-vs-external, segment scoping) and the OpenAPI segment-filter path has no e2e coverage yet, so merging there would be under-protected. The condition-filter algorithm is already shared via createConditionsFilter, so the remaining duplication is thin orchestration.

#6: documented (not removed) the ValidationPipe-shadowed InvalidLimitError / InvalidScopeError checks as intentional defense-in-depth fallbacks.

#9 (de-any the OpenAPI mappers) was evaluated and dropped — clean typing needs DTO-model rework or worse-than-any casts; poor ROI. It becomes easy once the upstream biz service returns precise types (a future follow-up).