### PR TITLE
chore(web): make dev proxy target configurable via SERVER_PROXY_TARGET

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,3 +2,9 @@ VITE_API_URL = ""
 VITE_USERTOUR_TOKEN = ""
 VITE_POSTHOG_KEY = ""
 VITE_POSTHOG_HOST = ""
+
+# Dev-only: backend URL the vite dev server proxies `/graphql` and `/api` to
+# (read by vite.config.ts). Set in apps/web/.env to override without editing
+# vite.config — a full URL, so port / https / docker all work.
+# Defaults to http://localhost:3000 when unset.
+# SERVER_PROXY_TARGET = "http://localhost:3000"

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,35 +1,43 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), mkcert()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-  server: {
-    port: 5174,
-    open: true,
-    https: false,
-    proxy: {
-      '/graphql': {
-        target: 'http://localhost:3000/graphql',
-        // target: 'https://local.usertour.io/graphql',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/graphql/, ''),
-      },
-      '/api': {
-        target: 'http://localhost:3000/api',
-        // target: 'https://local.usertour.io/api',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+export default defineConfig(({ mode }) => {
+  // Backend the dev server proxies to. Override locally WITHOUT editing this
+  // file via `SERVER_PROXY_TARGET` in `apps/web/.env` (gitignored) — a full
+  // URL, so it covers a different port, an https host, or a docker service
+  // (e.g. http://localhost:3001, https://local.usertour.io). Defaults to the
+  // conventional dev port.
+  const env = loadEnv(mode, __dirname, '');
+  const target = env.SERVER_PROXY_TARGET || 'http://localhost:3000';
+
+  return {
+    plugins: [react(), mkcert()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
       },
     },
-  },
+    server: {
+      port: 5174,
+      open: true,
+      https: false,
+      proxy: {
+        '/graphql': {
+          target: `${target}/graphql`,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/^\/graphql/, ''),
+        },
+        '/api': {
+          target: `${target}/api`,
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## What

`apps/web/vite.config.ts` no longer hardcodes the backend port. It reads
`SERVER_PROXY_TARGET` (a full URL) from `apps/web/.env`, defaulting to
`http://localhost:3000`. The `/graphql` and `/api` dev proxies derive their
target from it.

## Why

Previously the proxy target was hardcoded to `http://localhost:3000`, so anyone
running the backend on a different port (or an https host / docker service) had
to edit — and risk committing — `vite.config.ts`. Now personal overrides live in
the gitignored `apps/web/.env`; the committed config stays at a neutral default.

It's a full URL rather than just a port, so a different port, an https host, or a
docker service name all work without touching the committed config.

## Notes

- `apps/web/.env.example` documents the variable.
- Validated by loading the config via vite's own `loadConfigFromFile` — it
  resolves the target from `.env` (and falls back to `:3000` when unset).
- No app/runtime behavior change; dev-tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)