### PR TITLE
feat(builder): link to docs from element picker and custom CSS field

### DIFF
--- a/apps/web/src/components/element-picker-host.tsx
+++ b/apps/web/src/components/element-picker-host.tsx
@@ -271,6 +271,14 @@ export const ElementPickerHost = (props: ElementPickerHostProps) => {
                     {t('contentBuilder.elementPicker.urlInvalid')}
                   </p>
                 )}
+                <a
+                  href="https://docs.usertour.io/how-to-guides/selecting-elements"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-block pt-1 text-sm text-primary hover:underline"
+                >
+                  {t('contentBuilder.elementPicker.learnMore')}
+                </a>
               </div>
               <DialogFooter>
                 <Button type="button" variant="outline" onClick={() => settleUrlDialog(null)}>

--- a/apps/web/src/pages/settings/themes/components/theme-builder/fields/code-field.tsx
+++ b/apps/web/src/pages/settings/themes/components/theme-builder/fields/code-field.tsx
@@ -1,4 +1,5 @@
 import { CodeEditor, type CodeEditorLanguage } from '@usertour/editor';
+import { useTranslation } from 'react-i18next';
 import { useBuilderContext } from '../builder-context';
 import { FieldRow } from './field-row';
 
@@ -9,13 +10,17 @@ export interface CodeFieldProps {
   placeholder?: string;
   tooltip?: string;
   height?: string;
+  // Optional "Learn more" link rendered under the editor — e.g. the custom
+  // CSS field points at the custom-fonts-and-css guide.
+  docsHref?: string;
 }
 
 // Multi-line code field (CodeMirror) — used for the theme's custom CSS,
 // where syntax highlighting and bracket matching beat a plain textarea.
 export const CodeField = (props: CodeFieldProps) => {
-  const { path, label, language, placeholder, tooltip, height = '240px' } = props;
+  const { path, label, language, placeholder, tooltip, height = '240px', docsHref } = props;
   const { getField, setField, isReadOnly } = useBuilderContext();
+  const { t } = useTranslation();
   const value = getField<string>(path) ?? '';
   return (
     <FieldRow label={label} tooltip={tooltip} forceVertical>
@@ -29,6 +34,16 @@ export const CodeField = (props: CodeFieldProps) => {
           onChange={(next) => setField(path, next)}
         />
       </div>
+      {docsHref && (
+        <a
+          href={docsHref}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-1.5 inline-block text-sm text-primary hover:underline"
+        >
+          {t('themeBuilder.fields.customCss.docsLink')}
+        </a>
+      )}
     </FieldRow>
   );
 };

--- a/apps/web/src/pages/settings/themes/components/theme-builder/fields/field-renderer.tsx
+++ b/apps/web/src/pages/settings/themes/components/theme-builder/fields/field-renderer.tsx
@@ -126,6 +126,7 @@ export const FieldRenderer = (props: FieldRendererProps) => {
           placeholder={field.placeholder ? t(field.placeholder) : undefined}
           tooltip={tooltip}
           height={field.height}
+          docsHref={field.docsHref}
         />
       );
     case 'placement':

--- a/apps/web/src/pages/settings/themes/components/theme-builder/schema/sections.ts
+++ b/apps/web/src/pages/settings/themes/components/theme-builder/schema/sections.ts
@@ -1295,6 +1295,7 @@ export const builderSections: BuilderSection[] = [
         label: 'themeBuilder.fields.customCss.label',
         placeholder: 'themeBuilder.fields.customCss.placeholder',
         tooltip: 'themeBuilder.fields.customCss.tooltip',
+        docsHref: 'https://docs.usertour.io/how-to-guides/custom-fonts-and-css',
         requiresCustomCss: true,
       },
     ],

--- a/apps/web/src/pages/settings/themes/components/theme-builder/schema/types.ts
+++ b/apps/web/src/pages/settings/themes/components/theme-builder/schema/types.ts
@@ -84,6 +84,7 @@ export type FieldDef =
       language: 'css' | 'javascript';
       placeholder?: string;
       height?: string;
+      docsHref?: string;
     })
   | (FieldBase & {
       type: 'placement';

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -2292,6 +2292,7 @@ const translations = {
         placeholder: '@font-face {\n  font-family: "My Brand Sans";\n  src: url(...);\n}',
         tooltip:
           'Raw CSS injected into every widget (tooltips, modals, checklists, banners, resource center). Use it for @font-face rules backing the custom font, or for advanced style overrides. Widget internals may change between releases, so keep selectors as simple as possible.',
+        docsLink: 'Learn about custom fonts & CSS',
       },
       buttons: {
         height: 'Height',
@@ -2488,6 +2489,7 @@ const translations = {
       urlInvalid: 'Enter a valid URL',
       urlCancel: 'Cancel',
       urlConfirm: 'Open and pick',
+      learnMore: 'Learn how to pick stable elements',
     },
     editor: {
       button: {

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -2169,6 +2169,7 @@ const translations = {
         placeholder: '@font-face {\n  font-family: "My Brand Sans";\n  src: url(...);\n}',
         tooltip:
           '原样注入每个 widget(tooltip、modal、checklist、banner、资源中心)的 CSS。可用于声明自定义字体的 @font-face,也可做高级样式覆写。widget 内部结构可能随版本变化,选择器请尽量保持简单。',
+        docsLink: '了解自定义字体和 CSS',
       },
       buttons: {
         height: '高度',
@@ -2365,6 +2366,7 @@ const translations = {
       urlInvalid: '请输入有效的 URL',
       urlCancel: '取消',
       urlConfirm: '打开并选取',
+      learnMore: '了解如何稳定地选择元素',
     },
     editor: {
       button: {


### PR DESCRIPTION
Add a "Learn how to pick stable elements" link in the element picker's URL dialog (points at the selecting-elements guide), and a "Learn about custom fonts & CSS" link under the theme's custom CSS editor (points at the custom-fonts-and-css guide). The CSS link is schema-driven via an optional CodeField `docsHref` prop rather than hardcoded into the generic field.