### PR TITLE
fix(docker): only emit VITE_ vars into config.js, skip comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,9 @@ COPY . .
 
 # Generate config.js for web
 RUN echo "window.ENV = {" > ./apps/web/public/config.js && \
-    cat ./apps/web/.env.example | while read line; do \
-    if [ ! -z "$line" ]; then \
+    grep -E '^[[:space:]]*VITE_' ./apps/web/.env.example | while read line; do \
         var_name=$(echo $line | cut -d'=' -f1 | tr -d ' ' | sed 's/VITE_//'); \
         echo "  $var_name: '\$$var_name'," >> ./apps/web/public/config.js; \
-    fi \
     done && \
     echo "};" >> ./apps/web/public/config.js
 


### PR DESCRIPTION
The config.js generator looped over every non-empty line of apps/web/.env.example and turned it into a `key: '$key'` entry. It only skipped blank lines, not `#` comments — so the new SERVER_PROXY_TARGET doc comments became invalid JS keys (`#Dev-only...: '...'`), and the browser hit "Uncaught SyntaxError: Unexpected identifier '#Dev'", leaving window.ENV unloaded and the self-hosted web app blank.

Filter with `grep '^VITE_'` so only variable lines are emitted; comments, blank lines, and any non-VITE_ entries are ignored. The .env.example can now carry comments freely.