### PR TITLE
fix(theme): default to light until dark coverage is complete

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -16,7 +16,9 @@
       (function () {
         try {
           var raw = localStorage.getItem('USERTOUR@0.0.1/appearance');
-          var theme = raw ? JSON.parse(raw).value : 'system';
+          // Default light when unset — must match readStoredTheme() in
+          // src/contexts/theme-context.tsx.
+          var theme = raw ? JSON.parse(raw).value : 'light';
           var isDark =
             theme === 'dark' ||
             (theme === 'system' &&

--- a/apps/web/src/contexts/theme-context.tsx
+++ b/apps/web/src/contexts/theme-context.tsx
@@ -29,7 +29,14 @@ const readStoredTheme = (): Theme => {
   if (stored === 'light' || stored === 'dark' || stored === 'system') {
     return stored;
   }
-  return 'system';
+  // Default to light when nothing is stored (the user never picked). Not
+  // 'system': dark mode ships, but a few surfaces (builder takeover, billing,
+  // previews) are intentionally light, so a system-dark user shouldn't be
+  // auto-dropped into a partially-dark app. Only an explicit pick opts into
+  // system/dark — those are stored, so this default never touches them.
+  // Revisit (→ 'system') once dark coverage is complete. Keep in sync with the
+  // boot-script fallback in index.html.
+  return 'light';
 };
 
 const prefersDark = (): boolean => window.matchMedia(DARK_QUERY).matches;


### PR DESCRIPTION
Switch the unset-appearance fallback from 'system' to 'light' in both readStoredTheme() and the index.html boot script. Dark mode ships, but a few surfaces (builder takeover, billing, previews) are intentionally light, so a system-dark user shouldn't be auto-dropped into a partially dark app. Only affects users who never picked a theme (no stored value); anyone who explicitly chose system/dark/light has a stored value and is untouched.