### PR TITLE
refactor(sso): derive the callback URL from a single config source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,13 +40,18 @@ EMAIL_SENDER=YourApp <your-email@example.com>
 GITHUB_AUTH_ENABLED=false
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+# Optional — defaults to <API_URL>/api/auth/github/callback when unset
 GITHUB_CALLBACK_URL=http://localhost:8011/api/auth/github/callback
 
 # Google Authentication
 GOOGLE_AUTH_ENABLED=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Optional — defaults to <API_URL>/api/auth/google/callback when unset
 GOOGLE_CALLBACK_URL=http://localhost:8011/api/auth/google/callback
+
+# SSO (OIDC) — optional callback override; defaults to <API_URL>/api/auth/sso/callback
+SSO_CALLBACK_URL=
 
 # Outbound Security
 # Set to true only if your SSO identity provider is reachable on an internal network

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -50,13 +50,18 @@ EMAIL_SENDER=
 GITHUB_AUTH_ENABLED=false
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+# Optional — defaults to <API_URL>/api/auth/github/callback when unset
 GITHUB_CALLBACK_URL=
 
 # Google Authentication
 GOOGLE_AUTH_ENABLED=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+# Optional — defaults to <API_URL>/api/auth/google/callback when unset
 GOOGLE_CALLBACK_URL=
+
+# SSO (OIDC) — optional callback override; defaults to <API_URL>/api/auth/sso/callback
+SSO_CALLBACK_URL=
 
 # Outbound Security
 # Set to true only if your SSO identity provider is reachable on an internal network

--- a/apps/server/src/common/configs/config.interface.ts
+++ b/apps/server/src/common/configs/config.interface.ts
@@ -44,6 +44,7 @@ export interface Config {
     homepageUrl: string;
     apiUrl: string;
     docUrl: string;
+    ssoCallbackUrl: string;
   };
   aws: {
     s3: {

--- a/apps/server/src/common/configs/config.ts
+++ b/apps/server/src/common/configs/config.ts
@@ -46,6 +46,12 @@ const config: Config = {
     homepageUrl: process.env.APP_HOMEPAGE_URL || '',
     apiUrl: process.env.API_URL || '',
     docUrl: process.env.DOC_URL || '',
+    // The SSO OIDC redirect URI, defined once: override with SSO_CALLBACK_URL,
+    // otherwise derived from API_URL (fixed path). Both the openid-client
+    // redirect_uri and the value shown to admins (via globalConfig) read this,
+    // so the two can't drift.
+    ssoCallbackUrl:
+      process.env.SSO_CALLBACK_URL || `${process.env.API_URL || ''}/api/auth/sso/callback`,
   },
   aws: {
     s3: {
@@ -87,13 +93,15 @@ const config: Config = {
       enabled: process.env.GITHUB_AUTH_ENABLED === 'true',
       clientId: process.env.GITHUB_CLIENT_ID || 'test',
       clientSecret: process.env.GITHUB_CLIENT_SECRET || 'test',
-      callbackUrl: process.env.GITHUB_CALLBACK_URL || 'test',
+      callbackUrl:
+        process.env.GITHUB_CALLBACK_URL || `${process.env.API_URL || ''}/api/auth/github/callback`,
     },
     google: {
       enabled: process.env.GOOGLE_AUTH_ENABLED === 'true',
       clientId: process.env.GOOGLE_CLIENT_ID || 'test',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'test',
-      callbackUrl: process.env.GOOGLE_CALLBACK_URL || 'test',
+      callbackUrl:
+        process.env.GOOGLE_CALLBACK_URL || `${process.env.API_URL || ''}/api/auth/google/callback`,
     },
   },
   content: {

--- a/apps/server/src/schema.graphql
+++ b/apps/server/src/schema.graphql
@@ -628,6 +628,7 @@ type GlobalConfig {
   isSelfHostedMode: Boolean!
   needsSystemAdminSetup: Boolean!
   require2FA: Boolean!
+  ssoCallbackUrl: String
 }
 
 type InstallationStatus {

--- a/apps/server/src/sso/sso-oidc.service.ts
+++ b/apps/server/src/sso/sso-oidc.service.ts
@@ -45,8 +45,10 @@ export class SsoOidcService {
   // One fixed callback for every provider; the provider is resolved from the
   // signed tx cookie, so this is the single redirect URI to register at the IdP.
   buildCallbackUrl(): string {
-    const apiUrl = this.configService.get<string>('app.apiUrl') ?? '';
-    return `${apiUrl}/api/auth/sso/callback`;
+    // Single source of truth (app.ssoCallbackUrl: SSO_CALLBACK_URL override, else
+    // derived from API_URL) — same value globalConfig hands the admin UI, so what
+    // gets registered at the IdP matches the redirect_uri we send.
+    return this.configService.get<string>('app.ssoCallbackUrl') ?? '';
   }
 
   private async buildClient(provider: ProjectSSOIdentityProvider): Promise<Client> {

--- a/apps/server/src/utilities/models/global.model.ts
+++ b/apps/server/src/utilities/models/global.model.ts
@@ -8,6 +8,9 @@ export class GlobalConfig {
   @Field(() => String, { nullable: true })
   apiUrl: string;
 
+  @Field(() => String, { nullable: true })
+  ssoCallbackUrl: string;
+
   @Field(() => Boolean)
   allowUserRegistration: boolean;
 

--- a/apps/server/src/utilities/utilities.service.ts
+++ b/apps/server/src/utilities/utilities.service.ts
@@ -142,6 +142,7 @@ export class UtilitiesService {
     return {
       isSelfHostedMode,
       apiUrl,
+      ssoCallbackUrl: this.configService.get('app.ssoCallbackUrl'),
       allowUserRegistration,
       allowProjectLevelSubscriptionManagement,
       needsSystemAdminSetup,

--- a/apps/web/src/pages/settings/sso/components/sso-provider-dialog.tsx
+++ b/apps/web/src/pages/settings/sso/components/sso-provider-dialog.tsx
@@ -99,15 +99,13 @@ export const SsoProviderDialog = (props: SsoProviderDialogProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, provider?.id]);
 
-  // One fixed redirect URI for every provider — known up front, so it can be
-  // shown (and copied) in the create form, not just on edit. Built from the
-  // server-authoritative apiUrl (globalConfig) so the copied value is exactly
-  // the redirect_uri the backend sends to the IdP (no VITE_API_URL drift).
-  // SSO depends on API_URL being set; without it the callback is just a bare
-  // path, so warn (and block copy) instead of handing over a broken URL.
-  const apiUrl = globalConfig?.apiUrl ?? '';
-  const apiUrlMissing = !apiUrl;
-  const callbackUrl = `${apiUrl}/api/auth/sso/callback`;
+  // Server-authoritative redirect URI: globalConfig.ssoCallbackUrl is the single
+  // source of truth (SSO_CALLBACK_URL override, else derived from API_URL) — the
+  // exact value the backend sends to the IdP, so the copied URL can't drift from
+  // it. It's incomplete (a bare path, no host) when API_URL is unset and no
+  // override is configured; in that case warn and block copy.
+  const callbackUrl = globalConfig?.ssoCallbackUrl ?? '';
+  const apiUrlMissing = !/^https?:\/\//i.test(callbackUrl);
 
   return (
     <SettingsDialogForm

--- a/packages/gql/src/gql/utilities.ts
+++ b/packages/gql/src/gql/utilities.ts
@@ -15,6 +15,7 @@ export const globalConfig = gql`
     globalConfig {
       isSelfHostedMode
       apiUrl
+      ssoCallbackUrl
       allowUserRegistration
       allowProjectLevelSubscriptionManagement
       needsSystemAdminSetup

--- a/packages/types/src/types/common.ts
+++ b/packages/types/src/types/common.ts
@@ -53,6 +53,7 @@ export type SDKSettings = {
 export type GlobalConfig = {
   isSelfHostedMode: boolean;
   apiUrl: string;
+  ssoCallbackUrl: string;
   allowUserRegistration: boolean;
   allowProjectLevelSubscriptionManagement: boolean;
   needsSystemAdminSetup: boolean;


### PR DESCRIPTION
Define the SSO OIDC redirect URI once in config (app.ssoCallbackUrl: SSO_CALLBACK_URL override, else derived from API_URL). The backend openid-client redirect_uri and the value globalConfig hands the admin dialog now read that single value, so what gets registered at the IdP can't drift from what the dialog tells admins to paste in. The dialog reads globalConfig.ssoCallbackUrl instead of rebuilding the URL itself.

Collapse the Google/GitHub OAuth callbacks to the same pattern (env override, else derived from API_URL), and document SSO_CALLBACK_URL plus the now-optional OAuth callbacks in both .env.example files.