### PR TITLE
fix(announcement): point the list doc link at the new guide and fill …

### DIFF
--- a/apps/web/src/pages/contents/components/detail/tabs/overview/content-detail-announcement-editor.tsx
+++ b/apps/web/src/pages/contents/components/detail/tabs/overview/content-detail-announcement-editor.tsx
@@ -9,6 +9,7 @@ import { isVersionPublished } from '@/utils/content';
 import { useOembedInfo } from '@/pages/contents/components/builder/hooks/use-oembed-info';
 import { useAws, useContentListQuery } from '@usertour/hooks';
 import { ContentEditor, type ContentEditorRoot } from '@usertour/editor';
+import { ContentEditorSerialize } from '@usertour/widget';
 import { buildConfig, convertSettings, convertToCssVars } from '@usertour/helpers';
 import { cn } from '@usertour/tailwind';
 import {
@@ -603,18 +604,22 @@ const AnnouncementContentColumn = () => {
               ref={introEditorRef}
               className="border rounded-md p-3 min-h-[120px] usertour-widget-root"
             >
-              <ContentEditor
-                zIndex={10002}
-                customUploadRequest={upload}
-                initialValue={data.introContent}
-                onValueChange={handleIntroContentChange}
-                projectId={projectId}
-                attributes={attributeList}
-                contentList={contentList}
-                enabledElementTypes={ANNOUNCEMENT_ELEMENT_TYPES}
-                actionItems={ANNOUNCEMENT_ACTION_ITEMS}
-                getOembedInfo={getOembedInfo}
-              />
+              {isViewOnly ? (
+                <ContentEditorSerialize contents={data.introContent} />
+              ) : (
+                <ContentEditor
+                  zIndex={10002}
+                  customUploadRequest={upload}
+                  initialValue={data.introContent}
+                  onValueChange={handleIntroContentChange}
+                  projectId={projectId}
+                  attributes={attributeList}
+                  contentList={contentList}
+                  enabledElementTypes={ANNOUNCEMENT_ELEMENT_TYPES}
+                  actionItems={ANNOUNCEMENT_ACTION_ITEMS}
+                  getOembedInfo={getOembedInfo}
+                />
+              )}
             </div>
           </div>
         </CardContent>
@@ -672,18 +677,22 @@ const AnnouncementContentColumn = () => {
                 ref={detailEditorRef}
                 className={cn('border rounded-md p-3 min-h-[120px] usertour-widget-root')}
               >
-                <ContentEditor
-                  zIndex={10003}
-                  customUploadRequest={upload}
-                  initialValue={data.detailContent}
-                  onValueChange={handleDetailContentChange}
-                  projectId={projectId}
-                  attributes={attributeList}
-                  contentList={contentList}
-                  enabledElementTypes={ANNOUNCEMENT_ELEMENT_TYPES}
-                  actionItems={ANNOUNCEMENT_ACTION_ITEMS}
-                  getOembedInfo={getOembedInfo}
-                />
+                {isViewOnly ? (
+                  <ContentEditorSerialize contents={data.detailContent} />
+                ) : (
+                  <ContentEditor
+                    zIndex={10003}
+                    customUploadRequest={upload}
+                    initialValue={data.detailContent}
+                    onValueChange={handleDetailContentChange}
+                    projectId={projectId}
+                    attributes={attributeList}
+                    contentList={contentList}
+                    enabledElementTypes={ANNOUNCEMENT_ELEMENT_TYPES}
+                    actionItems={ANNOUNCEMENT_ACTION_ITEMS}
+                    getOembedInfo={getOembedInfo}
+                  />
+                )}
               </div>
             </div>
           </CardContent>

--- a/apps/web/src/pages/contents/components/detail/tabs/overview/content-detail-announcement-editor.tsx
+++ b/apps/web/src/pages/contents/components/detail/tabs/overview/content-detail-announcement-editor.tsx
@@ -7,7 +7,7 @@ import { useDefaultTheme, useThemeList } from '@/hooks/use-theme-list';
 import { useAttributeList } from '@/hooks/use-attribute-list';
 import { isVersionPublished } from '@/utils/content';
 import { useOembedInfo } from '@/pages/contents/components/builder/hooks/use-oembed-info';
-import { useAws } from '@usertour/hooks';
+import { useAws, useContentListQuery } from '@usertour/hooks';
 import { ContentEditor, type ContentEditorRoot } from '@usertour/editor';
 import { buildConfig, convertSettings, convertToCssVars } from '@usertour/helpers';
 import { cn } from '@usertour/tailwind';
@@ -469,11 +469,18 @@ const AnnouncementContentColumn = () => {
   const { contentId } = useContentDetailUI();
   const { content } = useContentDetail(contentId);
   const { version } = useContentVersion(content?.editedVersionId);
-  const { isViewOnly, project } = useAppContext();
+  const { isViewOnly, project, environment } = useAppContext();
   const { attributeList } = useAttributeList();
   const { upload } = useAws();
   const { themeList } = useThemeList();
   const getOembedInfo = useOembedInfo();
+
+  // Environment content list for the button-action pickers ("Start flow"
+  // lists the flows/checklists); without it the picker renders empty.
+  const { contents: contentList } = useContentListQuery({
+    query: { environmentId: environment?.id ?? '' },
+    options: { skip: !environment?.id },
+  });
 
   const { data, patchData } = useAnnouncementDraft();
 
@@ -603,6 +610,7 @@ const AnnouncementContentColumn = () => {
                 onValueChange={handleIntroContentChange}
                 projectId={projectId}
                 attributes={attributeList}
+                contentList={contentList}
                 enabledElementTypes={ANNOUNCEMENT_ELEMENT_TYPES}
                 actionItems={ANNOUNCEMENT_ACTION_ITEMS}
                 getOembedInfo={getOembedInfo}
@@ -671,6 +679,7 @@ const AnnouncementContentColumn = () => {
                   onValueChange={handleDetailContentChange}
                   projectId={projectId}
                   attributes={attributeList}
+                  contentList={contentList}
                   enabledElementTypes={ANNOUNCEMENT_ELEMENT_TYPES}
                   actionItems={ANNOUNCEMENT_ACTION_ITEMS}
                   getOembedInfo={getOembedInfo}

--- a/apps/web/src/pages/contents/list.tsx
+++ b/apps/web/src/pages/contents/list.tsx
@@ -199,7 +199,7 @@ const buildContentConfig = (t: TFunction): Record<string, ContentConfig> => {
       description: (
         <ContentDescription
           text={t('contents.list.announcements.text')}
-          docUrl="https://docs.usertour.io/how-to-guides/resource-center"
+          docUrl="https://docs.usertour.io/how-to-guides/announcements"
           linkText={t('contents.list.announcements.link')}
         />
       ),

--- a/packages/i18n/src/en-US/ui.ts
+++ b/packages/i18n/src/en-US/ui.ts
@@ -1602,7 +1602,7 @@ const translations = {
       announcements: {
         title: 'Announcements',
         text: 'Share product updates, release notes, and news with your users through the Resource Center.',
-        link: 'Read more in our Resource Center guide',
+        link: 'Read more in our Announcements guide',
         emptyTitle: 'No announcements added',
         emptyDescription: 'You have not added any announcements. Add one below.',
       },

--- a/packages/i18n/src/zh-Hans/ui.ts
+++ b/packages/i18n/src/zh-Hans/ui.ts
@@ -1518,7 +1518,7 @@ const translations = {
       announcements: {
         title: '公告',
         text: '通过资源中心向用户分享产品更新、发布说明和动态。',
-        link: '在《资源中心》指南中了解更多',
+        link: '在《公告》指南中了解更多',
         emptyTitle: '还没有公告',
         emptyDescription: '你还没有添加任何公告。在下方添加一个。',
       },


### PR DESCRIPTION
…the action content picker

- The announcements list header linked to the Resource Center guide; link to the new Announcements guide and update the link copy in both locales.
- The Start flow/checklist button action rendered an empty picker: the announcement detail editor never passed contentList into its two ContentEditor instances, so the actions context had no contents to offer. Fetch the list via the shared useContentListQuery (skipped until the environment is resolved), matching the builder embeds.