### PR TITLE
fix(localization): drop machine translations split across entries

### DIFF
--- a/apps/server/src/localizations/machine-translation.service.ts
+++ b/apps/server/src/localizations/machine-translation.service.ts
@@ -51,6 +51,7 @@ const SYSTEM_PROMPT = [
   '- Keep translations concise and natural for UI copy; match the tone and approximate length of the source.',
   '- Do not translate URLs, email addresses or code.',
   '- Return a translation for every item, keyed by its id.',
+  "- Return exactly one entry per item; never split an item's translation across multiple entries.",
 ].join('\n');
 
 @Injectable()
@@ -166,9 +167,30 @@ export class MachineTranslationService {
         prompt: JSON.stringify(payload),
         abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
-      return new Map(
-        result.object.translations.map((translation) => [translation.id, translation.text]),
-      );
+      // Models occasionally split one item's translation across several
+      // entries sharing the same id. A plain Map would keep only the last
+      // fragment, and joining is no better — observed splits are sometimes
+      // missing their tail. Drop such ids instead: the unit stays
+      // untranslated and the editor's retry channel picks it up.
+      const texts = new Map<number, string>();
+      const splitIds = new Set<number>();
+      for (const translation of result.object.translations) {
+        if (texts.has(translation.id)) {
+          splitIds.add(translation.id);
+        } else {
+          texts.set(translation.id, translation.text);
+        }
+      }
+      for (const id of splitIds) {
+        texts.delete(id);
+      }
+      if (splitIds.size > 0) {
+        this.logger.warn({
+          message: 'Machine translation split an item across entries; dropped for retry',
+          splitCount: splitIds.size,
+        });
+      }
+      return texts;
     } catch (error) {
       this.logger.error({ message: 'Machine translation request failed', error: `${error}` });
       throw new MachineTranslationFailedError();


### PR DESCRIPTION
Models occasionally return one item's translation as several entries sharing the same id (~20% of runs on claude-sonnet-4-6 via Bedrock, splitting at quoted-term boundaries). The id-keyed Map kept only the last fragment, saving tails like "选项卡。" as the whole translation; joining is no safer — observed splits sometimes miss their tail. Treat a duplicated id as untranslated instead and drop it: the editor's partial toast and re-click resume pick it up. A prompt rule states the one-entry contract, though measurement shows it doesn't reduce the split rate on its own.