### PR TITLE
fix(ai): enable structured outputs for the openai-compatible provider

### DIFF
--- a/apps/server/src/ai/ai.service.ts
+++ b/apps/server/src/ai/ai.service.ts
@@ -54,10 +54,17 @@ export class AiService {
       if (!baseUrl) {
         throw new AiNotConfiguredError();
       }
+      // Send real JSON-schema response_format instead of the default
+      // prompt-mode fallback: without it, OpenAI-family models reject
+      // json_object requests whose messages lack the literal word "JSON",
+      // and reasoning models leak thinking text into the object — both
+      // observed as blanket generateObject failures through OpenRouter and
+      // Bedrock Mantle. Requires the gateway to support structured outputs.
       const compatible = createOpenAICompatible({
         name: 'usertour-ai',
         apiKey,
         baseURL: baseUrl,
+        supportsStructuredOutputs: true,
       });
       this.model = compatible(modelId);
       return this.model;


### PR DESCRIPTION
Without the flag, generateObject falls back to prompt-mode JSON: OpenAI-family models reject json_object requests whose messages lack the literal word "JSON", and reasoning models leak thinking text into the object — machine translation failed on every call through OpenRouter. With real json_schema response_format the same prompt runs 30/30 clean.