### PR TITLE
fix(localization): keep locale rows rendered across a version swap

### DIFF
--- a/packages/hooks/src/hooks/content.ts
+++ b/packages/hooks/src/hooks/content.ts
@@ -67,13 +67,18 @@ export const useListVersionLocalizationsQuery = (
   versionId: string | undefined,
   options?: QueryHookOptions,
 ) => {
-  const { data, loading, refetch, error } = useQuery(listVersionLocalizations, {
+  const { data, previousData, loading, refetch, error } = useQuery(listVersionLocalizations, {
     variables: { versionId },
     skip: !versionId,
     ...options,
   });
 
-  const contentLocalizationList: VersionOnLocalization[] = data?.listVersionLocalizations ?? [];
+  // Fall back to the previous version's rows while a version switch loads —
+  // same pattern as useGetContentVersionQuery above. Editing a published
+  // version forks a draft whose rows are verbatim clones, and rendering an
+  // empty list during the swap reads as every locale flipping to disabled.
+  const contentLocalizationList: VersionOnLocalization[] =
+    (data ?? previousData)?.listVersionLocalizations ?? [];
 
   return { contentLocalizationList, loading, refetch, error };
 };


### PR DESCRIPTION
Toggling a locale on a published version forks a draft and repoints the page at it; the draft's localization rows had never been queried, so the table rendered an empty list for a frame — every Status switch flipped to disabled and back. Fall back to previousData while the swap loads, the same pattern useGetContentVersionQuery already uses; the forked rows are verbatim clones, so the previous list is correct.