### PR TITLE
fix(build): pin pnpm to 9.6.0 — unpinned latest broke the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 RUN apk add --no-cache openssl openssl-dev
 
 # Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.6.0
 
 # Copy all files (filtered by .dockerignore)
 COPY . .
@@ -46,7 +46,7 @@ FROM node:22.13-alpine
 WORKDIR /app
 
 # Install pnpm and system dependencies
-RUN npm install -g pnpm && \
+RUN npm install -g pnpm@9.6.0 && \
     apk add --no-cache nginx openssl openssl-dev libc6-compat gettext postgresql16-client
 
 # Copy nginx configuration

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "^9.1.6",
     "commitizen": "^4.2.4"
   },
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.6.0",
   "dependencies": {
     "rimraf": "^5.0.5",
     "tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
Both image stages ran `npm install -g pnpm` unpinned, so every build got whatever pnpm shipped last. A new pnpm 10 release sees the packageManager field (9.x), tries to self-switch by downloading the @pnpm/exe.linux-x64 native binary, and refuses because a v9 lockfile carries no integrity entry for it: "Cannot verify the identity of the @pnpm/exe.linux-x64 native binary". The build died on a line nobody had touched.

Pinned to 9.6.0 — the version that actually generates this lockfile locally — in both stages, and packageManager updated to match (it said 9.0.6, transposed digits; pnpm 9 never enforced it, so the typo was inert until pnpm 10 started reading it). Running version now equals the declared version, so the self-switch download can no longer trigger at all. frozen-lockfile install verified clean against the pin.