### PR TITLE
feat(oauth): MCP_SERVER_URL becomes the single truth for the advertis…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,10 @@ NODE_ENV=production
 
 # Web api url
 API_URL=""
-# Optional — full public MCP endpoint shown in Settings → MCP; defaults to <API_URL>/mcp
+# Optional — full public MCP endpoint; defaults to <API_URL>/mcp. Drives the
+# Settings → MCP display AND the OAuth metadata/401 challenge, so set it when
+# MCP is served on its own domain (which must also proxy /oauth/* and
+# /.well-known/oauth-*).
 # MCP_SERVER_URL=""
 
 # (redeploy trigger — no runtime effect)

--- a/apps/server/src/common/configs/config.ts
+++ b/apps/server/src/common/configs/config.ts
@@ -45,8 +45,13 @@ const config: Config = {
   app: {
     homepageUrl: process.env.APP_HOMEPAGE_URL || '',
     apiUrl: process.env.API_URL || '',
-    // Full public MCP endpoint shown in Settings -> MCP (e.g. https://api.usertour.io/mcp).
-    // Defaults to `${API_URL}/mcp` when unset.
+    // Full public MCP endpoint (e.g. https://api.usertour.io/mcp). Defaults to
+    // `${API_URL}/mcp` when unset. Single source of truth for THREE consumers:
+    // the Settings -> MCP display, the OAuth protected-resource metadata
+    // `resource` (clients validate it against the URL they connected to,
+    // RFC 9728), and the /mcp 401 challenge — so serving MCP on its own domain
+    // is just setting this (that domain must proxy /oauth/* and
+    // /.well-known/oauth-* too).
     mcpServerUrl:
       process.env.MCP_SERVER_URL ||
       (process.env.API_URL ? `${process.env.API_URL.replace(/\/+$/, '')}/mcp` : ''),

--- a/apps/server/src/common/filters/openapi-exception.filter.ts
+++ b/apps/server/src/common/filters/openapi-exception.filter.ts
@@ -11,7 +11,7 @@ import { ConfigService } from '@nestjs/config';
 import { BaseError } from '@/common/errors/base';
 import { OpenAPIError, ValidationError } from '@/common/errors/errors';
 import { ExpiredApiKeyError, InvalidApiKeyError, MissingApiKeyError } from '@/common/errors';
-import { resolveOrigin } from '@/common/http/resolve-origin';
+import { resolveMcpOrigin } from '@/common/http/resolve-origin';
 
 /**
  * Domain BaseErrors (thrown below the API layer, no HTTP status of their own)
@@ -104,7 +104,7 @@ export class OpenAPIExceptionFilter implements ExceptionFilter {
       exception instanceof ExpiredApiKeyError;
     if (isAuthError && request.path.replace(/\/+$/, '') === '/mcp') {
       status = HttpStatus.UNAUTHORIZED;
-      const origin = resolveOrigin(this.configService, request);
+      const origin = resolveMcpOrigin(this.configService, request);
       response.setHeader(
         'WWW-Authenticate',
         `Bearer realm="OAuth", resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp", error="invalid_token"`,

--- a/apps/server/src/common/http/resolve-origin.ts
+++ b/apps/server/src/common/http/resolve-origin.ts
@@ -15,3 +15,34 @@ export function resolveOrigin(config: ConfigService, req: Request): string {
   }
   return `${req.protocol}://${req.get('host')}`;
 }
+
+/**
+ * The MCP endpoint's public URL — `app.mcpServerUrl` (MCP_SERVER_URL), which
+ * defaults to `${API_URL}/mcp`, so with nothing configured this equals the
+ * old behavior. One knob, three consumers: the Settings page display, the
+ * protected-resource metadata `resource`, and the `/mcp` 401 challenge. They
+ * used to read DIFFERENT configs (display read MCP_SERVER_URL, metadata read
+ * API_URL), so a deployment serving MCP on its own domain told users one URL
+ * and clients another — RFC 9728 resource validation then refused the
+ * mismatch and the whole auth flow died.
+ */
+export function resolveMcpResource(config: ConfigService, req: Request): string {
+  const configured = config.get<string>('app.mcpServerUrl');
+  if (configured) {
+    return configured.replace(/\/+$/, '');
+  }
+  return `${resolveOrigin(config, req)}/mcp`;
+}
+
+/** Origin of {@link resolveMcpResource} — the base for the OAuth endpoints an
+ * MCP client is told to use, so that domain must proxy `/oauth/*` and
+ * `/.well-known/oauth-*` too (the nginx config does). */
+export function resolveMcpOrigin(config: ConfigService, req: Request): string {
+  try {
+    return new URL(resolveMcpResource(config, req)).origin;
+  } catch {
+    // Malformed MCP_SERVER_URL (no scheme) — fall back to the API origin
+    // rather than emitting metadata no client could validate.
+    return resolveOrigin(config, req);
+  }
+}

--- a/apps/server/src/oauth/oauth-discovery.controller.ts
+++ b/apps/server/src/oauth/oauth-discovery.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Req } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 
-import { resolveOrigin } from '@/common/http/resolve-origin';
+import { resolveMcpOrigin, resolveMcpResource } from '@/common/http/resolve-origin';
 
 import { buildAuthorizationServerMetadata, buildProtectedResourceMetadata } from './oauth-metadata';
 
@@ -19,11 +19,16 @@ export class OAuthDiscoveryController {
 
   @Get(['oauth-protected-resource', 'oauth-protected-resource/mcp'])
   protectedResource(@Req() req: Request) {
-    return buildProtectedResourceMetadata(resolveOrigin(this.config, req));
+    // MCP-derived, not the API origin: when MCP_SERVER_URL puts /mcp on its
+    // own domain, `resource` must equal the URL clients actually connect to.
+    return buildProtectedResourceMetadata(
+      resolveMcpOrigin(this.config, req),
+      resolveMcpResource(this.config, req),
+    );
   }
 
   @Get(['oauth-authorization-server', 'oauth-authorization-server/mcp'])
   authorizationServer(@Req() req: Request) {
-    return buildAuthorizationServerMetadata(resolveOrigin(this.config, req));
+    return buildAuthorizationServerMetadata(resolveMcpOrigin(this.config, req));
   }
 }

--- a/apps/server/src/oauth/oauth-metadata.spec.ts
+++ b/apps/server/src/oauth/oauth-metadata.spec.ts
@@ -4,7 +4,7 @@ const ORIGIN = 'https://api.usertour.io';
 
 describe('oauth discovery metadata', () => {
   it('protected-resource metadata points /mcp at this server as its own AS', () => {
-    const m = buildProtectedResourceMetadata(ORIGIN);
+    const m = buildProtectedResourceMetadata(ORIGIN, `${ORIGIN}/mcp`);
     expect(m.resource).toBe(`${ORIGIN}/mcp`);
     expect(m.authorization_servers).toEqual([ORIGIN]);
     expect(m.bearer_methods_supported).toEqual(['header']);

--- a/apps/server/src/oauth/oauth-metadata.ts
+++ b/apps/server/src/oauth/oauth-metadata.ts
@@ -26,10 +26,18 @@ export interface AuthorizationServerMetadata {
 // stored on a token's `scopes` and intersected with the owner's role per request.
 const SCOPES_SUPPORTED = Object.values(Capability);
 
-/** The MCP resource (`<origin>/mcp`) points back at this server as its own AS. */
-export function buildProtectedResourceMetadata(origin: string): ProtectedResourceMetadata {
+/**
+ * The MCP resource points back at this server as its own AS. `resource` is the
+ * EXACT public MCP URL (clients compare it against the URL they connected to,
+ * RFC 9728) — passed in rather than derived so it stays byte-identical to what
+ * resolveMcpResource serves everywhere else.
+ */
+export function buildProtectedResourceMetadata(
+  origin: string,
+  resource: string,
+): ProtectedResourceMetadata {
   return {
-    resource: `${origin}/mcp`,
+    resource,
     authorization_servers: [origin],
     scopes_supported: SCOPES_SUPPORTED,
     bearer_methods_supported: ['header'],

--- a/apps/server/test/e2e/oauth/oauth.e2e-spec.ts
+++ b/apps/server/test/e2e/oauth/oauth.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 
 import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from 'nestjs-prisma';
 import request from 'supertest';
 
@@ -69,6 +70,35 @@ describe('OAuth 2.1 AS for MCP (e2e)', () => {
     const as = await http().get('/.well-known/oauth-authorization-server').expect(200);
     expect(as.body.code_challenge_methods_supported).toEqual(['S256']);
     expect(as.body.grant_types_supported).toContain('authorization_code');
+  });
+
+  it('MCP_SERVER_URL is the single truth for the advertised resource (split-domain MCP)', async () => {
+    // Display read MCP_SERVER_URL while the metadata read API_URL, so a
+    // deployment serving /mcp on its own domain told users one URL and OAuth
+    // clients another — RFC 9728 resource validation then refused the mismatch
+    // ("Protected resource X does not match expected Y") and auth died. All
+    // three surfaces now derive from app.mcpServerUrl.
+    const config = app.get(ConfigService);
+    const prev = config.get('app.mcpServerUrl');
+    config.set('app.mcpServerUrl', 'https://mcp2.example.com/mcp');
+    try {
+      const prm = await http().get('/.well-known/oauth-protected-resource/mcp').expect(200);
+      expect(prm.body.resource).toBe('https://mcp2.example.com/mcp');
+      expect(prm.body.authorization_servers).toEqual(['https://mcp2.example.com']);
+
+      // The AS endpoints follow the MCP origin (that domain proxies /oauth/*).
+      const as = await http().get('/.well-known/oauth-authorization-server').expect(200);
+      expect(as.body.issuer).toBe('https://mcp2.example.com');
+      expect(as.body.token_endpoint).toBe('https://mcp2.example.com/oauth/token');
+
+      // The /mcp 401 challenge points at the SAME origin's metadata.
+      const denied = await http().post('/mcp').send({}).expect(401);
+      expect(denied.headers['www-authenticate']).toContain(
+        'https://mcp2.example.com/.well-known/oauth-protected-resource/mcp',
+      );
+    } finally {
+      config.set('app.mcpServerUrl', prev);
+    }
   });
 
   it('rejects a non-allowlisted DCR redirect_uri', async () => {


### PR DESCRIPTION
…ed MCP resource

Serving /mcp on its own domain died at auth: the client connected to the MCP domain, but the protected-resource metadata advertised the API_URL origin (resolveOrigin prefers the configured canonical host), and RFC 9728 resource validation refused the mismatch — "Protected resource X does not match expected Y". Root cause was a split brain: the Settings display read MCP_SERVER_URL while the metadata and the /mcp 401 challenge read API_URL.

All three now derive from app.mcpServerUrl (which already defaults to `${API_URL}/mcp`, so an unset variable keeps today's behavior byte-for-byte): the metadata `resource` is the configured endpoint verbatim, authorization_servers/issuer and the /oauth/* endpoints follow its origin, and the 401 WWW-Authenticate points at the same origin's well-known. Split-domain MCP is now just setting MCP_SERVER_URL — that domain must also proxy /oauth/* and /.well-known/oauth-* (the shipped nginx config does; stated in .env.example and the config comment).

Browser-facing consent stays on the dashboard origin (homepageUrl) where the login cookie lives — only the machine-to-machine endpoints follow the MCP origin.

e2e pins the whole chain under a foreign MCP_SERVER_URL: resource, authorization_servers, issuer, token_endpoint and the 401 header all move together.