### PR TITLE
fix(auth): social login resumes the interrupted flow (MCP consent) in…

### DIFF
--- a/apps/server/src/auth/auth.controller.spec.ts
+++ b/apps/server/src/auth/auth.controller.spec.ts
@@ -11,6 +11,13 @@ describe('AuthController — social OAuth callback', () => {
     get: (key: string) => (key === 'app.homepageUrl' ? homepage : undefined),
   } as any;
   const makeRes = () => ({ redirect: jest.fn() }) as any;
+  /** A callback request whose OAuth state carries the given payload. */
+  const makeReq = (statePayload?: Record<string, unknown>) =>
+    ({
+      query: statePayload
+        ? { state: Buffer.from(JSON.stringify(statePayload)).toString('base64') }
+        : {},
+    }) as any;
 
   it('routes a force-SSO social login to the project SSO entry (not a generic error)', async () => {
     const res = makeRes();
@@ -20,7 +27,7 @@ describe('AuthController — social OAuth callback', () => {
     } as any;
     const controller = new AuthController(auth, config);
 
-    await controller.githubAuthCallback({ id: 'u1', email: 'a@b.co' } as any, res);
+    await controller.githubAuthCallback({ id: 'u1', email: 'a@b.co' } as any, makeReq(), res);
 
     expect(res.redirect).toHaveBeenCalledWith(`${homepage}/auth/sso/proj-1`);
     expect(auth.setAuthCookie).not.toHaveBeenCalled();
@@ -34,9 +41,80 @@ describe('AuthController — social OAuth callback', () => {
     } as any;
     const controller = new AuthController(auth, config);
 
-    await controller.googleAuthCallback({ id: 'u1', email: 'a@b.co' } as any, res);
+    await controller.googleAuthCallback({ id: 'u1', email: 'a@b.co' } as any, makeReq(), res);
 
     expect(auth.setAuthCookie).toHaveBeenCalled();
     expect(res.redirect).toHaveBeenCalledWith(homepage);
+  });
+
+  it('resumes an interrupted flow: `next` from the OAuth state survives the login', async () => {
+    // The field case: MCP consent page -> signin -> Google -> callback. The
+    // consent path rides the state round-trip and the callback lands ON it —
+    // before this, the callback hard-redirected to the homepage and the whole
+    // MCP authorization died quietly.
+    const res = makeRes();
+    const auth = {
+      issueTokensOrChallenge: jest.fn().mockResolvedValue({ kind: 'tokens', tokens: {} }),
+      setAuthCookie: jest.fn().mockReturnValue(res),
+    } as any;
+    const controller = new AuthController(auth, config);
+
+    const next = '/oauth-consent?transaction=abc';
+    await controller.googleAuthCallback({ id: 'u1' } as any, makeReq({ next }), res);
+
+    expect(res.redirect).toHaveBeenCalledWith(`${homepage}${next}`);
+  });
+
+  it('resumes even when `next` is long: the MCP transaction JWT (~590 chars) is NOT truncated away', async () => {
+    // The field bug: a 512-char cap dropped the real MCP next (transaction JWT
+    // = all scopes + PKCE), so the flow this feature resumes was the one it
+    // silently killed. Pin a next longer than 512.
+    const res = makeRes();
+    const auth = {
+      issueTokensOrChallenge: jest.fn().mockResolvedValue({ kind: 'tokens', tokens: {} }),
+      setAuthCookie: jest.fn().mockReturnValue(res),
+    } as any;
+    const controller = new AuthController(auth, config);
+
+    const longNext = `/oauth-consent?transaction=${'x'.repeat(600)}`;
+    expect(longNext.length).toBeGreaterThan(512);
+    await controller.googleAuthCallback({ id: 'u1' } as any, makeReq({ next: longNext }), res);
+
+    expect(res.redirect).toHaveBeenCalledWith(`${homepage}${longNext}`);
+  });
+
+  it('refuses a non-same-origin `next` (open-redirect guard): falls back to homepage', async () => {
+    const res = makeRes();
+    const auth = {
+      issueTokensOrChallenge: jest.fn().mockResolvedValue({ kind: 'tokens', tokens: {} }),
+      setAuthCookie: jest.fn().mockReturnValue(res),
+    } as any;
+    const controller = new AuthController(auth, config);
+
+    for (const evil of ['https://evil.example.com/x', '//evil.example.com', 'oauth-consent']) {
+      await controller.googleAuthCallback({ id: 'u1' } as any, makeReq({ next: evil }), res);
+      expect(res.redirect).toHaveBeenLastCalledWith(homepage);
+    }
+  });
+
+  it('forwards `next` through the 2FA challenge redirect', async () => {
+    const res = makeRes();
+    const auth = {
+      issueTokensOrChallenge: jest
+        .fn()
+        .mockResolvedValue({ kind: 'challenge', purpose: 'mfa-verify', challengeToken: 'ch1' }),
+      setAuthCookie: jest.fn(),
+    } as any;
+    const controller = new AuthController(auth, config);
+
+    await controller.googleAuthCallback(
+      { id: 'u1' } as any,
+      makeReq({ next: '/oauth-consent?transaction=abc' }),
+      res,
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      `${homepage}/auth/2fa?challenge=ch1&next=${encodeURIComponent('/oauth-consent?transaction=abc')}`,
+    );
   });
 });

--- a/apps/server/src/auth/auth.controller.ts
+++ b/apps/server/src/auth/auth.controller.ts
@@ -11,6 +11,38 @@ import { User } from '@/users/models/user.model';
 import { AuthenticationExpiredError, OAuthError, SsoRequiredError } from '@/common/errors';
 import { REFRESH_TOKEN_COOKIE } from '@/utils/cookie';
 
+/**
+ * Same-origin `next` path from the OAuth `state` round-trip, or undefined.
+ * State is CLIENT-controlled input echoed back by the provider, so this is the
+ * load-bearing validation: only a relative path ('/x', never '//x' or an
+ * absolute URL) may become a redirect target — anything else would be an open
+ * redirect. Mirrors the web's resolveNextPath rules.
+ */
+function nextFromState(req: Request): string | undefined {
+  const state = req.query?.state;
+  if (typeof state !== 'string' || !state) {
+    return undefined;
+  }
+  try {
+    const next = JSON.parse(Buffer.from(state, 'base64').toString()).next;
+    // 2048, not 512: the MCP consent path carries a `transaction` JWT (all
+    // granted scopes + PKCE challenge), so a real `next` is ~590 chars — a
+    // 512 cap silently dropped exactly the flow this exists to resume. The
+    // bound only guards against an absurdly long state, not business length.
+    if (
+      typeof next === 'string' &&
+      next.startsWith('/') &&
+      !next.startsWith('//') &&
+      next.length <= 2048
+    ) {
+      return next;
+    }
+  } catch {
+    /* malformed state is the strategy's problem (it throws OAuthError) */
+  }
+  return undefined;
+}
+
 @Controller('api/auth')
 export class AuthController {
   private readonly logger = new Logger(AuthController.name);
@@ -37,10 +69,10 @@ export class AuthController {
   @UseGuards(GithubOauthGuard)
   @Get('github/callback')
   @Public()
-  async githubAuthCallback(@UserEntity() user: User, @Res() res: Response) {
+  async githubAuthCallback(@UserEntity() user: User, @Req() req: Request, @Res() res: Response) {
     try {
       this.logger.log(`github oauth callback success, req.user = ${user?.email}`);
-      await this.finishOauth(user.id, res);
+      await this.finishOauth(user.id, res, nextFromState(req));
     } catch (error) {
       this.logger.error('GitHub OAuth callback failed:', error.stack);
       throw new OAuthError();
@@ -50,10 +82,10 @@ export class AuthController {
   @UseGuards(GoogleOauthGuard)
   @Get('google/callback')
   @Public()
-  async googleAuthCallback(@UserEntity() user: User, @Res() res: Response) {
+  async googleAuthCallback(@UserEntity() user: User, @Req() req: Request, @Res() res: Response) {
     try {
       this.logger.log(`google oauth callback success, req.user = ${user?.email}`);
-      await this.finishOauth(user.id, res);
+      await this.finishOauth(user.id, res, nextFromState(req));
     } catch (error) {
       this.logger.error('Google OAuth callback failed:', error.stack);
       throw new OAuthError();
@@ -65,7 +97,7 @@ export class AuthController {
    * the user on the app, or redirect them to the 2FA second-step / setup page
    * with a short-lived challenge token in the URL.
    */
-  private async finishOauth(userId: string, res: Response) {
+  private async finishOauth(userId: string, res: Response, next?: string) {
     const homepage = this.configService.get<string>('app.homepageUrl') || '';
     let result: Awaited<ReturnType<AuthService['issueTokensOrChallenge']>>;
     try {
@@ -81,12 +113,18 @@ export class AuthController {
       throw error;
     }
     if (result.kind === 'tokens') {
-      // Land at SPA root and let LandingRedirect pick the user's env.
-      this.auth.setAuthCookie(res, result.tokens).redirect(homepage || '/');
+      // Resume the interrupted flow (`next` from the OAuth state — e.g. the MCP
+      // consent page) or land at SPA root and let LandingRedirect pick the env.
+      this.auth
+        .setAuthCookie(res, result.tokens)
+        .redirect(next ? `${homepage}${next}` : homepage || '/');
       return;
     }
     const path = result.purpose === 'mfa-verify' ? '/auth/2fa' : '/auth/2fa/setup';
-    const url = `${homepage}${path}?challenge=${encodeURIComponent(result.challengeToken)}`;
+    // Forward `next` into the 2FA step: the web's useAuthAfterLogin reads it
+    // off the page URL after verification and resumes the flow.
+    const forwardNext = next ? `&next=${encodeURIComponent(next)}` : '';
+    const url = `${homepage}${path}?challenge=${encodeURIComponent(result.challengeToken)}${forwardNext}`;
     res.redirect(url);
   }
 

--- a/apps/server/src/auth/guard/github-oauth.guard.ts
+++ b/apps/server/src/auth/guard/github-oauth.guard.ts
@@ -13,13 +13,21 @@ export class GithubOauthGuard extends AuthGuard('github') {
 
   getAuthenticateOptions(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();
-    const { inviteCode } = request.query;
+    const { inviteCode, next } = request.query;
 
-    if (inviteCode) {
-      const state = Buffer.from(JSON.stringify({ inviteCode })).toString('base64');
-      return {
-        state,
-      };
+    // `next` rides the OAuth state round-trip like inviteCode, so a login that
+    // interrupted another flow (the MCP OAuth consent page) can resume it.
+    // Only same-origin path shapes are carried; the callback re-validates
+    // before redirecting (state is client-controlled input).
+    const payload: Record<string, string> = {};
+    if (typeof inviteCode === 'string' && inviteCode) {
+      payload.inviteCode = inviteCode;
+    }
+    if (typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')) {
+      payload.next = next;
+    }
+    if (Object.keys(payload).length > 0) {
+      return { state: Buffer.from(JSON.stringify(payload)).toString('base64') };
     }
     return {};
   }

--- a/apps/server/src/auth/guard/google-oauth.guard.ts
+++ b/apps/server/src/auth/guard/google-oauth.guard.ts
@@ -12,13 +12,21 @@ export class GoogleOauthGuard extends AuthGuard('google') {
   }
   getAuthenticateOptions(context: ExecutionContext) {
     const request = context.switchToHttp().getRequest();
-    const { inviteCode } = request.query;
+    const { inviteCode, next } = request.query;
 
-    if (inviteCode) {
-      const state = Buffer.from(JSON.stringify({ inviteCode })).toString('base64');
-      return {
-        state,
-      };
+    // `next` rides the OAuth state round-trip like inviteCode, so a login that
+    // interrupted another flow (the MCP OAuth consent page) can resume it.
+    // Only same-origin path shapes are carried; the callback re-validates
+    // before redirecting (state is client-controlled input).
+    const payload: Record<string, string> = {};
+    if (typeof inviteCode === 'string' && inviteCode) {
+      payload.inviteCode = inviteCode;
+    }
+    if (typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')) {
+      payload.next = next;
+    }
+    if (Object.keys(payload).length > 0) {
+      return { state: Buffer.from(JSON.stringify(payload)).toString('base64') };
     }
     return {};
   }

--- a/apps/web/src/pages/authentication/components/social-providers.tsx
+++ b/apps/web/src/pages/authentication/components/social-providers.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import { Button } from '@usertour/ui';
 import { GithubIcon, GoogleIcon, SpinnerIcon } from '@usertour/icons';
 import { apiUrl } from '@/utils/env';
@@ -13,10 +14,22 @@ interface SocialProvidersProps {
   inviteCode?: string;
 }
 
-const buildHref = (provider: AuthProvider, inviteCode?: string) =>
-  inviteCode
-    ? `${apiUrl}/api/auth/${provider}?inviteCode=${inviteCode}`
-    : `${apiUrl}/api/auth/${provider}`;
+// `next` rides along so the server can thread it through the OAuth state
+// round-trip and land the callback back on the interrupted flow (e.g. the MCP
+// consent page). Without it, a social login always ended on the homepage and
+// silently killed whatever needed the login. Same-origin validation happens
+// server-side; this only forwards.
+const buildHref = (provider: AuthProvider, inviteCode?: string, next?: string | null) => {
+  const params = new URLSearchParams();
+  if (inviteCode) {
+    params.set('inviteCode', inviteCode);
+  }
+  if (next?.startsWith('/') && !next.startsWith('//')) {
+    params.set('next', next);
+  }
+  const qs = params.toString();
+  return `${apiUrl}/api/auth/${provider}${qs ? `?${qs}` : ''}`;
+};
 
 export const SocialProviders = ({
   googleEnabled,
@@ -26,6 +39,7 @@ export const SocialProviders = ({
 }: SocialProvidersProps) => {
   const { t } = useTranslation('ui');
   const [pending, setPending] = useState<AuthProvider | null>(null);
+  const [searchParams] = useSearchParams();
 
   if (!googleEnabled && !githubEnabled) {
     return null;
@@ -33,7 +47,7 @@ export const SocialProviders = ({
 
   const launch = (provider: AuthProvider) => {
     setPending(provider);
-    window.location.href = buildHref(provider, inviteCode);
+    window.location.href = buildHref(provider, inviteCode, searchParams.get('next'));
   };
 
   return (


### PR DESCRIPTION
…stead of dropping to homepage

A social (Google/GitHub) login started from the MCP OAuth consent page never came back to it: the callback hard-redirected to the homepage, so the MCP authorization died silently and the client hung until timeout. Two gaps: the entry link carried only inviteCode (not `next`), and the callback had no logic to consume it.

`next` now rides the OAuth state round-trip beside inviteCode (both guards), and finishOauth lands on it — the token branch redirects to `homepage+next`, the 2FA branch forwards `next` into the challenge URL (the web's useAuthAfterLogin picks it up after verification). The callback re-validates state as same-origin before redirecting (client- controlled input): only a relative path, never `//` or an absolute URL — an open-redirect guard mirroring the web's resolveNextPath.

The length bound is 2048, not the 512 first written: a real MCP `next` is `/oauth-consent?transaction=<JWT>` (~590 chars, the JWT holding every granted scope + PKCE challenge), so 512 truncated away exactly the flow this resumes. Regression pins a 600-char next surviving; open-redirect and 2FA-forward cases pinned too. Same fix covers both providers (one decoder, one finishOauth).

Known gap (post-launch): SSO (OIDC) login is a separate pipeline and still drops `next`.