### PR TITLE
fix(web): personal API keys docs link points at v2, not the v1 API re…

### DIFF
--- a/apps/web/src/pages/settings/personal-api-keys/personal-api-keys-list.tsx
+++ b/apps/web/src/pages/settings/personal-api-keys/personal-api-keys-list.tsx
@@ -180,7 +180,7 @@ export const PersonalApiKeysList = () => {
           />
           <br />
           <a
-            href="https://docs.usertour.io/api-reference/introduction"
+            href="https://docs.usertour.io/api-reference-v2/introduction"
             className="text-primary"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
…ference

The "learn more" link went to /api-reference/introduction (the v1 OpenAPI docs), but personal API keys authenticate the new v2 REST surface — so the page sent readers to the wrong API. Now /api-reference-v2/introduction.

Left the identical link on the environment Access Tokens page (api-list) and the Integrations header alone: the former manages the v1 access tokens (openapi.guard), so v1 is correct there; the latter is a separate mis-target (it should point at integration docs, not any API reference) worth its own fix later.