### PR TITLE
fix(web): rotated API key is actually shown — the reveal dialog no lo…

### DIFF
--- a/apps/web/src/pages/settings/personal-api-keys/components/row-actions.tsx
+++ b/apps/web/src/pages/settings/personal-api-keys/components/row-actions.tsx
@@ -8,10 +8,17 @@ import {
 } from '@usertour/hooks';
 import { DestructiveConfirmDialog, ResourceRowActions, useToast } from '@usertour/ui';
 import { EditDialog } from './edit-dialog';
-import { RevealDialog } from './reveal-dialog';
 
 interface RowActionsProps {
   token: ApiToken;
+  /**
+   * Reports the freshly-minted plaintext secret after a rotate. The reveal
+   * dialog is owned by the page, NOT this row: the row lives inside the table
+   * subtree, which the list page swaps for a skeleton while the post-mutation
+   * refetch is in flight — any state held here would be destroyed with it,
+   * and the one-time secret is not retrievable again.
+   */
+  onRotated: (token: string) => void;
 }
 
 /**
@@ -23,11 +30,10 @@ interface RowActionsProps {
  * leaked key).
  */
 export const RowActions = (props: RowActionsProps) => {
-  const { token } = props;
+  const { token, onRotated } = props;
   const [editOpen, setEditOpen] = useState(false);
   const [rotateOpen, setRotateOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [rotatedToken, setRotatedToken] = useState('');
   const { invoke: rotateApiToken, loading: isRotating } = useRotateApiTokenMutation();
   const { invoke: deleteApiToken, loading: isDeleting } = useDeleteApiTokenMutation();
   const { toast } = useToast();
@@ -38,7 +44,7 @@ export const RowActions = (props: RowActionsProps) => {
       const result = await rotateApiToken(token.id);
       if (result) {
         setRotateOpen(false);
-        setRotatedToken(result.token);
+        onRotated(result.token);
         toast({ variant: 'success', title: t('settings.personalApiKeys.rotateSuccess') });
       } else {
         toast({ variant: 'destructive', title: t('settings.personalApiKeys.rotateFailure') });
@@ -127,12 +133,6 @@ export const RowActions = (props: RowActionsProps) => {
         onOpenChange={setDeleteOpen}
         onConfirm={handleDelete}
         loading={isDeleting}
-      />
-
-      <RevealDialog
-        token={rotatedToken}
-        open={!!rotatedToken}
-        onOpenChange={() => setRotatedToken('')}
       />
     </>
   );

--- a/apps/web/src/pages/settings/personal-api-keys/personal-api-keys-list.tsx
+++ b/apps/web/src/pages/settings/personal-api-keys/personal-api-keys-list.tsx
@@ -16,6 +16,7 @@ import { type ApiToken, useListApiTokensQuery } from '@usertour/hooks';
 import { useAppContext } from '@/contexts/app-context';
 import { SHARED_CACHE_QUERY_OPTIONS } from '@/apollo/options';
 import { CreateDialog } from './components/create-dialog';
+import { RevealDialog } from './components/reveal-dialog';
 import { RowActions } from './components/row-actions';
 import { SCOPE_RESOURCES, summarizeScopes } from '@/components/token-scopes';
 
@@ -37,11 +38,12 @@ const NewKeyButton = ({ onSuccess }: { onSuccess: () => void }) => {
 
 export const PersonalApiKeysList = () => {
   const { projects } = useAppContext();
-  // Skipping `isRefetching` here on purpose — Apollo's `loading` flag stays
-  // false for refetches, so the table updates in place instead of flashing
-  // back to the skeleton when a token is created/deleted.
   const { apiTokens, loading, refetch } = useListApiTokensQuery(SHARED_CACHE_QUERY_OPTIONS);
   const { t } = useTranslation();
+  // Rotate's one-time secret reveal. Owned by the page, not the table row —
+  // the table subtree is replaced by the skeleton during refetches, which
+  // would destroy any row-held state (and this secret is unrecoverable).
+  const [rotatedToken, setRotatedToken] = useState('');
 
   const projectNameById = useMemo(() => {
     const index: Record<string, string> = {};
@@ -162,40 +164,50 @@ export const PersonalApiKeysList = () => {
     {
       header: '',
       headerClassName: 'w-20',
-      cell: (token) => <RowActions token={token} />,
+      cell: (token) => <RowActions token={token} onRotated={setRotatedToken} />,
     },
   ];
 
   return (
-    <ResourceListPage<ApiToken>
-      title={t('settings.personalApiKeys.title')}
-      actions={<NewKeyButton onSuccess={refetch} />}
-      description={
-        <>
-          {t('settings.personalApiKeys.description')}
-          <br />
-          <Trans
-            i18nKey="settings.personalApiKeys.descriptionOnce"
-            components={{ strong: <span className="font-bold text-foreground" /> }}
-          />
-          <br />
-          <a
-            href="https://docs.usertour.io/api-reference-v2/introduction"
-            className="text-primary"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <span>{t('settings.personalApiKeys.headerDocs')}</span>
-            <OpenInNewWindowIcon className="size-3.5 inline ml-0.5 mb-0.5" />
-          </a>
-        </>
-      }
-      columns={columns}
-      rows={apiTokens}
-      loading={loading}
-      empty={t('settings.personalApiKeys.empty')}
-      getRowKey={(token) => token.id}
-    />
+    <>
+      <ResourceListPage<ApiToken>
+        title={t('settings.personalApiKeys.title')}
+        actions={<NewKeyButton onSuccess={refetch} />}
+        description={
+          <>
+            {t('settings.personalApiKeys.description')}
+            <br />
+            <Trans
+              i18nKey="settings.personalApiKeys.descriptionOnce"
+              components={{ strong: <span className="font-bold text-foreground" /> }}
+            />
+            <br />
+            <a
+              href="https://docs.usertour.io/api-reference-v2/introduction"
+              className="text-primary"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <span>{t('settings.personalApiKeys.headerDocs')}</span>
+              <OpenInNewWindowIcon className="size-3.5 inline ml-0.5 mb-0.5" />
+            </a>
+          </>
+        }
+        columns={columns}
+        rows={apiTokens}
+        // Not bare `loading`: the list hook turns on notifyOnNetworkStatusChange,
+        // so every refetch flips it too — and swapping the table for the skeleton
+        // mid-refetch would unmount the rows. Skeleton only before first data.
+        loading={loading && !apiTokens}
+        empty={t('settings.personalApiKeys.empty')}
+        getRowKey={(token) => token.id}
+      />
+      <RevealDialog
+        token={rotatedToken}
+        open={!!rotatedToken}
+        onOpenChange={() => setRotatedToken('')}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
…nger dies with the table

Rotate minted the new secret and toasted "copy the new secret now", but nothing displayed it: the reveal state lived in RowActions, a table cell. The list hook sets notifyOnNetworkStatusChange, so the refetch that follows the mutation flips `loading` back on, ResourceListBody swaps the whole table for the skeleton, and the row unmounts — taking the secret with it. Since rotate has already invalidated the old secret, the key was left unusable: old one dead, new one never seen.

The reveal now belongs to the page (state + RevealDialog outside the table subtree; the row reports the secret through onRotated), and the skeleton is gated on the first load only (`loading && !apiTokens`) instead of every refetch. That second half also fixes a wider annoyance the old comment got backwards — it claimed Apollo keeps `loading` false on refetch, so create/delete/edit were flashing the skeleton too.