### PR TITLE
fix(docker): graceful shutdown — exec-form CMD and Node as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,5 +83,10 @@ ENV NEST_SERVER_PORT=3000
 
 EXPOSE 80
 
-# Use shell form for proper stdout/stderr log flushing
-CMD /app/scripts/start.sh
+# Exec (JSON) form: no `sh -c` wrapper, so the signal chain reaches the app —
+# start.sh ends with `exec node`, making Node PID 1; Nest's shutdown hooks
+# (main.ts enableShutdownHooks) then handle SIGTERM and `docker stop` is
+# graceful instead of a 10s timeout + SIGKILL. (Shell vs exec form has no
+# effect on stdout/stderr — both inherit the same pipes; the old "log
+# flushing" rationale for shell form was a misattribution.)
+CMD ["/app/scripts/start.sh"]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -51,5 +51,8 @@ done
 # Seed database
 npx prisma db seed
 
-# Start Node.js server
-node dist/main
+# Start Node.js server. `exec` replaces this shell so Node becomes PID 1:
+# SIGTERM from `docker stop` reaches Nest's shutdown hooks directly (without
+# exec, the shell holds PID 1, ignores the signal by PID-1 rules, and the
+# container is SIGKILLed after the grace period).
+exec node dist/main


### PR DESCRIPTION
`docker stop` always burned the 10s grace period and SIGKILLed: the shell-form CMD wrapped start.sh in `sh -c`, and the script ran node as a child of its shell — either way a shell held PID 1 with no SIGTERM handler, and PID 1 ignores default-disposition signals outright.

CMD moves to exec (JSON) form and start.sh ends with `exec node`, so Node IS PID 1; Nest's enableShutdownHooks (already in main.ts) receives SIGTERM and closes the HTTP server, Redis and Prisma cleanly. Also clears the JSONArgsRecommended build warning (docker build --check is clean).

The old comment claimed shell form helped "stdout/stderr log flushing" (d3a301b5e) — both forms inherit identical stdio pipes; that rationale was a misattribution and is corrected in place.