### PR TITLE
fix(webhooks): the downgraded banner waits for the page to settle

### DIFF
--- a/apps/web/src/pages/settings/webhooks/components/webhook-detail.tsx
+++ b/apps/web/src/pages/settings/webhooks/components/webhook-detail.tsx
@@ -489,7 +489,10 @@ const MessagesSection = ({
 export const WebhookDetail = () => {
   const { settingSubType: webhookId } = useParams();
   const { project } = useAppContext();
-  const { projectConfig } = useGetProjectConfigQuery(project?.id, SHARED_CACHE_QUERY_OPTIONS);
+  const { projectConfig, loading: configLoading } = useGetProjectConfigQuery(
+    project?.id,
+    SHARED_CACHE_QUERY_OPTIONS,
+  );
   // Cache-connected (repo default is no-cache with per-query opt-in): rotate
   // and update merge their returned fields into Webhook:<id>, and this watch
   // query must be ON the cache to see them — without this, the new secret
@@ -500,7 +503,10 @@ export const WebhookDetail = () => {
   const { t } = useTranslation();
   // Plan gate mirror (server enforces independently): reads and delete stay
   // open on a downgraded project; rotate / test / resend are write-shaped.
-  const entitled = !projectConfig || projectConfig.webhooks;
+  // Optimistic while settling — see webhook-list: the transiently-actived
+  // wrong project's config must not flash the downgraded banner here.
+  const rawEntitled = !projectConfig || projectConfig.webhooks;
+  const entitled = (loading && !webhook) || (configLoading && !projectConfig) ? true : rawEntitled;
 
   if (loading && !webhook) {
     return null;

--- a/apps/web/src/pages/settings/webhooks/webhook-list.tsx
+++ b/apps/web/src/pages/settings/webhooks/webhook-list.tsx
@@ -50,8 +50,17 @@ export const SettingsWebhookList = () => {
   // server deliberately leaves reads and deletes open so old configuration
   // can be inspected and cleaned up); the full-page upsell is only for
   // projects with nothing to show.
+  //
+  // OPTIMISTIC while settling: on a hard refresh the account-level actived
+  // project can transiently be a DIFFERENT (un-entitled) project before the
+  // route syncs it — its webhooks:false config arrives first and the
+  // downgraded banner flashes over the skeletons. An assertive plan claim
+  // must only render once this page's queries have settled; until then we
+  // present as entitled (the server still enforces every mutation).
   const entitled = !projectConfig || projectConfig.webhooks;
-  if (!entitled && !loading && (webhooks?.length ?? 0) === 0) {
+  const settled = !!environment && !(loading && !webhooks) && !(configLoading && !projectConfig);
+  const entitledView = settled ? entitled : true;
+  if (!entitledView && !loading && (webhooks?.length ?? 0) === 0) {
     return <WebhookUpsell projectId={project?.id} environmentName={environment?.name ?? ''} />;
   }
 
@@ -133,16 +142,16 @@ export const SettingsWebhookList = () => {
     {
       header: '',
       headerClassName: 'w-20',
-      cell: (webhook) => <WebhookRowActions webhook={webhook} entitled={entitled} />,
+      cell: (webhook) => <WebhookRowActions webhook={webhook} entitled={entitledView} />,
     },
   ];
 
   return (
     <ResourceListPage<Webhook>
       title={t('settings.webhooks.title', { environment: environment?.name ?? '' })}
-      actions={entitled ? <NewWebhookButton /> : undefined}
+      actions={entitledView ? <NewWebhookButton /> : undefined}
       description={
-        entitled ? (
+        entitledView ? (
           t('settings.webhooks.headerBody')
         ) : (
           <span className="text-amber-600">{t('settings.webhooks.downgraded.banner')}</span>


### PR DESCRIPTION
On a hard refresh the account-level actived project can transiently be a DIFFERENT (un-entitled) project before the route syncs it — its webhooks:false config lands first and the plan banner flashes over the loading skeletons (seen on staging, where the round-trip is long enough to watch). An assertive plan claim now renders only once this page's own queries have settled; until then the page presents as entitled — display only, every mutation stays server-enforced. Same treatment on the detail page. The root cause (URL projectId should take precedence over the actived flag in app-context) affects every project-scoped page and is tracked as a separate app-level item.