### PR TITLE
fix(webhooks): one settled flag for the banner and the upsell branch

### DIFF
--- a/apps/web/src/pages/settings/webhooks/webhook-list.tsx
+++ b/apps/web/src/pages/settings/webhooks/webhook-list.tsx
@@ -51,16 +51,22 @@ export const SettingsWebhookList = () => {
   // can be inspected and cleaned up); the full-page upsell is only for
   // projects with nothing to show.
   //
-  // OPTIMISTIC while settling: on a hard refresh the account-level actived
-  // project can transiently be a DIFFERENT (un-entitled) project before the
-  // route syncs it — its webhooks:false config arrives first and the
-  // downgraded banner flashes over the skeletons. An assertive plan claim
-  // must only render once this page's queries have settled; until then we
-  // present as entitled (the server still enforces every mutation).
+  // OPTIMISTIC while settling, with ONE settled flag shared by every branch
+  // below. Two reasons an assertive plan claim must wait:
+  //   - hard refresh: the account-level actived project can transiently be a
+  //     DIFFERENT (un-entitled) project before the route syncs it;
+  //   - navigating in from another settings page: projectConfig is already
+  //     cached (webhooks:false available on frame one) while this page's own
+  //     list is still in flight.
+  // The second case is why the flag is shared: when the banner and the upsell
+  // branch used different readiness tests, an un-entitled project with no
+  // endpoints rendered "banner + empty table" — telling the user to review
+  // endpoints that don't exist, with no way to create one — until the list
+  // arrived. Display only; the server enforces every mutation regardless.
   const entitled = !projectConfig || projectConfig.webhooks;
-  const settled = !!environment && !(loading && !webhooks) && !(configLoading && !projectConfig);
+  const settled = !!environment && !!webhooks && !!projectConfig;
   const entitledView = settled ? entitled : true;
-  if (!entitledView && !loading && (webhooks?.length ?? 0) === 0) {
+  if (!entitledView && webhooks?.length === 0) {
     return <WebhookUpsell projectId={project?.id} environmentName={environment?.name ?? ''} />;
   }
 


### PR DESCRIPTION
Navigating in from another settings page has projectConfig already cached (webhooks:false on frame one) while this page's list is still in flight — and the banner and the upsell branch tested readiness differently, so an un-entitled project with no endpoints rendered "downgraded banner + empty table": told to review endpoints that don't exist, with no way to create one, until the list landed. Both now hang off a single `settled` flag derived from data presence (not loading flags, which flip on cache-and-network refetches), so the page shows one coherent state: optimistic until settled, then list / degraded list / upsell.