### PR TITLE
fix(web): integrations list settles through skeleton cards, not the l…

### DIFF
--- a/apps/web/src/pages/settings/integrations/components/integration-upsell.tsx
+++ b/apps/web/src/pages/settings/integrations/components/integration-upsell.tsx
@@ -24,6 +24,10 @@ export const IntegrationUpsell = (props: IntegrationUpsellProps) => {
     <SettingsPage
       title={t('settings.integrations.title', { environment: environmentName })}
       description={t('settings.integrations.headerBody')}
+      docs={{
+        href: 'https://docs.usertour.io/how-to-guides/integrations',
+        label: t('settings.common.readGuide', { topic: t('settings.nav.sections.integrations') }),
+      }}
     >
       <div className="flex h-[450px] shrink-0 items-center justify-center rounded-md border border-dashed">
         <div className="mx-auto flex max-w-[420px] flex-col items-center justify-center text-center">

--- a/apps/web/src/pages/settings/integrations/integration-list.tsx
+++ b/apps/web/src/pages/settings/integrations/integration-list.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useGetProjectConfigQuery, useListIntegrationsQuery } from '@usertour/hooks';
-import { Button, SettingsPage } from '@usertour/ui';
+import { Button, SettingsPage, Skeleton } from '@usertour/ui';
 import { SHARED_CACHE_QUERY_OPTIONS } from '@/apollo/options';
 import { useAppContext } from '@/contexts/app-context';
 import { useCooldownTick } from '../components/use-cooldown-tick';
@@ -34,6 +34,38 @@ export const SettingsIntegrationList = () => {
   const entitledView = settled ? entitled : true;
   if (!entitledView && integrations?.length === 0) {
     return <IntegrationUpsell projectId={project?.id} environmentName={environment?.name ?? ''} />;
+  }
+  // While settling, show skeleton cards instead of the real catalog: an
+  // un-entitled project would otherwise flash the full five-card catalog and
+  // then flip to the upsell — a content reversal, where skeleton-to-outcome
+  // reads as loading. Entitled projects fill the same layout in place.
+  if (!settled) {
+    return (
+      <SettingsPage
+        title={t('settings.integrations.title', { environment: environment?.name ?? '' })}
+        description={t('settings.integrations.headerBody')}
+        docs={{
+          href: INTEGRATIONS_DOCS_HREF,
+          label: t('settings.common.readGuide', { topic: t('settings.nav.sections.integrations') }),
+        }}
+      >
+        <ul className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          {INTEGRATION_CATALOG.map((entry) => (
+            <li
+              key={entry.provider}
+              className="rounded-xl border bg-card px-4 py-6 dark:bg-surface-raised"
+            >
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-8 w-8 rounded-lg" />
+                <Skeleton className="h-8 w-20 rounded-md" />
+              </div>
+              <Skeleton className="mt-3 h-4 w-24" />
+              <Skeleton className="mt-2 h-4 w-48" />
+            </li>
+          ))}
+        </ul>
+      </SettingsPage>
+    );
   }
 
   return (


### PR DESCRIPTION
…ive catalog

The plan gate renders optimistically while the config and list queries resolve; the catalog is static, so an un-entitled project flashed all five provider cards before flipping to the upsell. Skeleton cards in the same layout make the settle read as loading — entitled projects fill in place, un-entitled ones transition once. Header (title, description, docs link) is identical across skeleton, catalog, and upsell so nothing jumps.