### PR TITLE
fix(zapier): publishing review follow-ups — HTTPS-only server URL, find-or-create pairing (1.1.4)

### DIFF
--- a/integrations/zapier/CHANGELOG.md
+++ b/integrations/zapier/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.4
+
+Publishing review follow-ups: HTTPS-only server URLs and paired find-or-create steps.
+
+1. Update authentication: the server URL must use https://; plain http:// URLs are rejected with a clear message.
+2. New search-or-create! search/find_user paired with create/upsert_user.
+3. New search-or-create! search/find_company paired with create/upsert_company.
+4. Update trigger/user_created: description no longer mentions the integration name.
+
 ## 1.1.3
 
 Attribute values now follow each attribute's declared type, and self-hosted instances behind a path prefix paginate correctly.

--- a/integrations/zapier/authentication.js
+++ b/integrations/zapier/authentication.js
@@ -23,7 +23,7 @@ module.exports = {
       required: true,
       default: 'https://api.usertour.io',
       helpText:
-        'Usertour Cloud uses the default. Self-hosted? Enter your instance API URL (the same host your SDK talks to). See https://docs.usertour.io/api-reference-v2/introduction.',
+        'Usertour Cloud uses the default. Self-hosted? Enter your instance API URL (the same host your SDK talks to). It must use https://. See https://docs.usertour.io/api-reference-v2/introduction.',
     },
     {
       key: 'apiToken',

--- a/integrations/zapier/index.js
+++ b/integrations/zapier/index.js
@@ -55,4 +55,26 @@ module.exports = {
     [findUser.key]: findUser,
     [findCompany.key]: findCompany,
   },
+  // "Find or Create": the search step grows a checkbox that runs the paired
+  // action when nothing is found. The keys must match the search keys.
+  searchOrCreates: {
+    [findUser.key]: {
+      key: findUser.key,
+      display: {
+        label: 'Find or Create User',
+        description: 'Finds a user by their user ID, or creates the user if none exists.',
+      },
+      search: findUser.key,
+      create: upsertUser.key,
+    },
+    [findCompany.key]: {
+      key: findCompany.key,
+      display: {
+        label: 'Find or Create Company',
+        description: 'Finds a company by its company ID, or creates the company if none exists.',
+      },
+      search: findCompany.key,
+      create: upsertCompany.key,
+    },
+  },
 };

--- a/integrations/zapier/lib/api.js
+++ b/integrations/zapier/lib/api.js
@@ -10,11 +10,19 @@
  * Normalized API origin from auth data: trims whitespace, strips trailing
  * slashes (self-hosted users paste those constantly, and `//v2/...` 404s on
  * both express and the bundled nginx), and defaults a missing scheme to
- * https.
+ * https. Plain http is refused rather than silently upgraded: Zapier reaches
+ * a self-hosted instance over the public internet with a bearer token, so
+ * the connection must be TLS end to end, and an upgraded URL that then fails
+ * to connect would be harder to diagnose than a clear message.
  */
 const apiBase = (bundle) => {
   let url = (bundle.authData.serverUrl || '').trim().replace(/\/+$/, '');
-  if (!/^https?:\/\//i.test(url)) {
+  if (/^http:\/\//i.test(url)) {
+    throw new Error(
+      'Server URL must start with https:// — Zapier only connects to your instance over HTTPS.',
+    );
+  }
+  if (!/^https:\/\//i.test(url)) {
     url = `https://${url}`;
   }
   return url;
@@ -32,7 +40,9 @@ const environmentUrl = (bundle, path) =>
  * re-attached: plain concatenation keeps it, `new URL(link, base)` drops it.
  */
 const absoluteUrl = (bundle, link) =>
-  /^https?:\/\//i.test(link) ? link : `${apiBase(bundle)}${link}`;
+  /^https?:\/\//i.test(link)
+    ? link.replace(/^http:\/\//i, 'https://')
+    : `${apiBase(bundle)}${link}`;
 
 /**
  * Walk a cursor-paginated v2 collection to the end (capped so a runaway

--- a/integrations/zapier/package.json
+++ b/integrations/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usertour-zapier",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Usertour integration for Zapier: trigger Zaps from Usertour events, and create or update Usertour users from other apps.",
   "main": "index.js",
   "private": true,

--- a/integrations/zapier/triggers/index.js
+++ b/integrations/zapier/triggers/index.js
@@ -48,7 +48,7 @@ const userCreated = hookTrigger({
   key: 'user_created',
   noun: 'User',
   label: 'User Created',
-  description: 'Triggers when a user is seen by Usertour for the first time.',
+  description: 'Triggers when a user is seen for the first time.',
   topic: 'user.created',
   sample: samples.userCreated,
 });


### PR DESCRIPTION
Two items from the Zapier publishing review, app version 1.1.4 (already pushed to Zapier; promotion is locked until the review is unlocked).

- **HTTPS only.** The Server URL field refuses plain `http://` with a clear message instead of sending bearer tokens over HTTP; a missing scheme still defaults to `https://`. Absolute pagination links are upgraded to https as well.
- **Find or Create.** Find User and Find Company are wired as search-or-creates, paired with the Create or Update actions, so the search step offers the standard "create if not found" checkbox. The standalone upserts stay for one-step syncs.
- **Naming.** The User Created description no longer names the integration.

Only `integrations/zapier/` changes; nothing in server or web, so no deployment is needed.

Verification: `zapier-platform validate` passes 25/25 checks with the same 8 pre-existing non-blocking warnings; URL normalization probed locally for missing scheme, trailing slashes, uppercase scheme, and `http://`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
