### PR TITLE
chore: declare the MCP server for the official registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.usertour/mcp",
+  "title": "Usertour MCP Server",
+  "description": "Official Usertour MCP Server for in-app onboarding: flows, checklists, surveys, and analytics.",
+  "version": "0.9.4",
+  "websiteUrl": "https://usertour.io",
+  "repository": {
+    "url": "https://github.com/usertour/usertour",
+    "source": "github",
+    "subfolder": "apps/server/src/mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.usertour.io/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `server.json` at the repo root so we can list our hosted MCP endpoint on [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/) — the upstream feed for the client-side server directories (GitHub MCP Registry, aggregators, in-client browsers). One publish, everything downstream syncs.

### What's in the entry

| Field | Value |
| --- | --- |
| Namespace | `io.github.usertour/mcp` |
| Endpoint | `https://mcp.usertour.io/mcp` (streamable-http) |
| Repository | this repo, `subfolder: apps/server/src/mcp` |
| Version | `0.9.4` (tracks the product release) |

**The namespace is the proof of authenticity.** Publishing under `io.github.usertour/*` requires GitHub org-**owner** auth at publish time, so the name itself proves the entry is ours — descriptions claiming "Official" are just text, anyone can write them.

**No `headers` block, unlike most entries.** PostHog and friends make users create an API key by hand and paste it as a bearer header. Our endpoint advertises OAuth 2.1 discovery, so clients authorize in the browser — nothing to copy. That difference shows up directly in the listing.

### Why the repo root

- It is outward-facing metadata like README/Dockerfile, not implementation code
- Keeps it out of the build output (`apps/server/src/**` gets compiled into `dist`)
- `mcp-publisher` reads `server.json` from the working directory, so publishing runs from the repo root

Same placement as [apolloio/apollo-mcp-plugin](https://github.com/apolloio/apollo-mcp-plugin/blob/main/server.json). PostHog keeps theirs out of version control entirely — which we deliberately don't copy: in-repo means the entry is reviewable, the version can't silently drift from the product, and CI publishing stays an option.

### Validated

Checked field-by-field against the official `2025-12-11/server.schema.json`: required fields, no unknown fields, namespace pattern, description/title length, repository shape, remote transport shape — all pass. (The first draft's description was 129 chars against a 100 limit; shortened.)

### After merge

Publishing is a separate manual step (needs GitHub org-owner auth), run from the repo root:

```bash
brew install mcp-publisher
mcp-publisher login github
mcp-publisher validate
mcp-publisher publish
```

Publishing is self-serve — no review queue; the entry is live immediately. Worth adding to the release checklist so the version stays in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

