### PR TITLE
ci: publish the MCP registry entry on release tags

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,45 @@
+name: Publish MCP Registry Entry
+
+# Keeps our listing on registry.modelcontextprotocol.io in sync with releases.
+# OIDC, not a personal token: it authenticates as THIS repository, which also
+# sidesteps the interactive-login bug where org namespaces are refused
+# (modelcontextprotocol/registry#1468, #1527, #1537, #1551).
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish server.json to the MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # mint the OIDC token mcp-publisher exchanges
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # The tag is the source of truth for the published version, so a release
+      # can never ship with a stale server.json. Nothing is committed back —
+      # the in-repo value is only the fallback for a manual publish.
+      - name: Set version from the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+          echo "Publishing version $VERSION"
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish
+        run: ./mcp-publisher publish


### PR DESCRIPTION
Follow-up to #479, which added `server.json`. The entry is now live on the registry ([`io.github.usertour/mcp`](https://registry.modelcontextprotocol.io/), active, v0.9.4) — this automates keeping it current.

### Why

A registry listing only changes when it is re-published, so its version drifts from the product the moment anyone forgets. This runs on the same `v*` tags the Docker image build already uses and takes the version **from the tag**, so a release cannot ship a stale entry. Nothing is committed back; the in-repo `version` stays the fallback for a manual publish.

### Why OIDC and not a token

Publishing under the `io.github.usertour/*` namespace via `mcp-publisher login github` returns 403 even with org-owner role and public membership — a known upstream bug with four open issues (modelcontextprotocol/registry [#1468](https://github.com/modelcontextprotocol/registry/issues/1468), [#1527](https://github.com/modelcontextprotocol/registry/issues/1527), [#1537](https://github.com/modelcontextprotocol/registry/issues/1537), [#1551](https://github.com/modelcontextprotocol/registry/issues/1551)), and the 403's own "make your membership public" advice is itself filed as misleading ([#1483](https://github.com/modelcontextprotocol/registry/issues/1483)).

`login github-oidc` verifies **this repository's** identity instead of asking which orgs a human belongs to, so it never reaches that code path — the workaround confirmed in #1537 and the approach the registry docs recommend anyway. It also means no personal access token to mint, store, or rotate.

`mcp-publisher validate` runs before publishing, so a schema-invalid entry fails here rather than upstream.

### Verified

- Workflow YAML parses; steps, triggers and `permissions` (`id-token: write`) as intended
- The tag→version step dry-run against the real `server.json`: tag `v0.9.5` yields `"version": "0.9.5"` with every other field intact
- `id-token` is never granted by default and is requested explicitly here, so the repo's `read` default workflow permission doesn't block it — no repo setting to flip

First real run will be the next `v*` tag; `workflow_dispatch` is enabled for a manual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)