### PR TITLE
MCP registry listing + automated republish on release tags

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,45 @@
+name: Publish MCP Registry Entry
+
+# Keeps our listing on registry.modelcontextprotocol.io in sync with releases.
+# OIDC, not a personal token: it authenticates as THIS repository, which also
+# sidesteps the interactive-login bug where org namespaces are refused
+# (modelcontextprotocol/registry#1468, #1527, #1537, #1551).
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish server.json to the MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # mint the OIDC token mcp-publisher exchanges
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # The tag is the source of truth for the published version, so a release
+      # can never ship with a stale server.json. Nothing is committed back —
+      # the in-repo value is only the fallback for a manual publish.
+      - name: Set version from the tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+          echo "Publishing version $VERSION"
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.usertour/mcp",
+  "title": "Usertour MCP Server",
+  "description": "Official Usertour MCP Server for in-app onboarding: flows, checklists, surveys, and analytics.",
+  "version": "0.9.4",
+  "websiteUrl": "https://usertour.io",
+  "repository": {
+    "url": "https://github.com/usertour/usertour",
+    "source": "github",
+    "subfolder": "apps/server/src/mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.usertour.io/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Ships the two pieces behind our listing on [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/) — the upstream feed for client-side MCP server directories. The entry is already live and active as [`io.github.usertour/mcp`](https://registry.modelcontextprotocol.io/) v0.9.4; this brings the source of truth into the repo.

### `server.json` (#479)

Declares the hosted endpoint for the registry:

| Field | Value |
| --- | --- |
| Namespace | `io.github.usertour/mcp` |
| Endpoint | `https://mcp.usertour.io/mcp` (streamable-http) |
| Repository | this repo, `subfolder: apps/server/src/mcp` |

The namespace is the authenticity proof — publishing under `io.github.usertour/*` requires org-owner auth, so the name itself is the claim, not the "Official" wording in a description anyone can write.

**No `headers` block, unlike most entries.** Peer listings make users create an API key by hand and paste it as a bearer header; our endpoint advertises OAuth 2.1 discovery, so clients authorize in the browser with nothing to copy. Lives at the repo root: outward metadata like README/Dockerfile, kept out of `apps/server/src` so it stays out of the build output, and where `mcp-publisher` expects it.

### Publish workflow (#480)

A listing only changes when re-published, so its version drifts from the product the moment anyone forgets. The workflow runs on the same `v*` tags as the Docker image build and takes the version **from the tag** — a release can't ship a stale entry. Nothing is committed back; the in-repo `version` is the fallback for a manual publish.

It authenticates with `login github-oidc`, which verifies **this repository's** identity rather than asking which orgs a human belongs to. That is both the documented recommendation and a necessary workaround: the interactive `login github` path returns 403 for org namespaces even with owner role and public membership (modelcontextprotocol/registry [#1468](https://github.com/modelcontextprotocol/registry/issues/1468), [#1527](https://github.com/modelcontextprotocol/registry/issues/1527), [#1537](https://github.com/modelcontextprotocol/registry/issues/1537), [#1551](https://github.com/modelcontextprotocol/registry/issues/1551), all open). It also means no personal access token to store or rotate. `mcp-publisher validate` gates the publish.

### Verified

- `server.json` checked field-by-field against the official `2025-12-11` schema — required fields, namespace pattern, description/title lengths, repository and remote shapes
- Entry confirmed live via the registry API: active, `isLatest`, correct endpoint, no headers
- Workflow YAML parses; tag→version step dry-run on the real file (`v0.9.5` → `"version": "0.9.5"`, all other fields intact)
- `id-token` is never granted by default and is requested explicitly, so the repo's `read` default workflow permission doesn't block it

No product code touched — two files, both additive. The workflow's first real run is the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)