### PR TITLE
chore(hubspot): register the staging callback URL

### DIFF
--- a/integrations/hubspot/src/app/app-hsmeta.json
+++ b/integrations/hubspot/src/app/app-hsmeta.json
@@ -10,6 +10,7 @@
       "type": "oauth",
       "redirectUrls": [
         "https://api.usertour.io/api/integrations/hubspot/oauth/callback",
+        "https://staging.usertour.io/api/integrations/hubspot/oauth/callback",
         "http://localhost:5174/api/integrations/hubspot/oauth/callback"
       ],
       "requiredScopes": [


### PR DESCRIPTION
Follow-up to #482: the HubSpot app's redirect list gains `https://staging.usertour.io/api/integrations/hubspot/oauth/callback` (app build #12 is already deployed with it), so Connect works on staging. No server or web changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)