### PR TITLE
chore(hubspot): the question header always shows the answer

### DIFF
--- a/integrations/hubspot/src/app/app-events/question_answered-company-hsmeta.json
+++ b/integrations/hubspot/src/app/app-events/question_answered-company-hsmeta.json
@@ -4,7 +4,7 @@
   "config": {
     "name": "Question answered",
     "description": "A user answered a survey question in Usertour (NPS, scale, text or choice).",
-    "headerTemplate": "Question answered: **{{question_name}}**{{#if answer}} \u00b7 {{answer}}{{/if}}",
+    "headerTemplate": "Question answered: **{{question_name}}** \u00b7 {{answer}}",
     "objectType": "COMPANY",
     "properties": [
       {

--- a/integrations/hubspot/src/app/app-events/question_answered-contact-hsmeta.json
+++ b/integrations/hubspot/src/app/app-events/question_answered-contact-hsmeta.json
@@ -4,7 +4,7 @@
   "config": {
     "name": "Question answered",
     "description": "A user answered a survey question in Usertour (NPS, scale, text or choice).",
-    "headerTemplate": "Question answered: **{{question_name}}**{{#if answer}} \u00b7 {{answer}}{{/if}}",
+    "headerTemplate": "Question answered: **{{question_name}}** \u00b7 {{answer}}",
     "objectType": "CONTACT",
     "properties": [
       {


### PR DESCRIPTION
Follow-up to #488: the "Question answered" timeline header no longer guards the answer with a conditional — a question that was answered always has one, and a guard would make an answer of 0 depend on the renderer's idea of truthiness. App build #18 is deployed with it. hsmeta only, no server or web change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)