### PR TITLE
fix(web): the mapping dialog does not offer Usertour's own write-back properties as fields to sync in

### DIFF
--- a/apps/web/src/pages/settings/integrations/components/object-mapping-dialog.tsx
+++ b/apps/web/src/pages/settings/integrations/components/object-mapping-dialog.tsx
@@ -31,6 +31,7 @@ import {
 } from '@usertour/ui';
 import {
   type IntegrationCatalogEntry,
+  SYNC_REMOTE_PROPERTY_GROUP,
   localDataTypeFor,
   remotePropertyNameFor,
 } from '@usertour/constants';
@@ -141,10 +142,16 @@ export const ObjectMappingDialog = (props: ObjectMappingDialogProps) => {
         .map((property) => ({ value: property.name, label: property.label, hint: property.name })),
     [properties],
   );
+  // The provider's Usertour group holds our own write-backs: syncing one of
+  // those in would only echo a value Usertour already has, under a second name.
   const inboundOptions = useMemo(
     () =>
       properties
-        .filter((property) => !inboundSet.has(property.name))
+        .filter(
+          (property) =>
+            !inboundSet.has(property.name) &&
+            property.groupName !== SYNC_REMOTE_PROPERTY_GROUP.name,
+        )
         .map((property) => ({
           value: property.name,
           label: property.readOnly


### PR DESCRIPTION
The provider's Usertour group holds the properties this integration writes back. Offering them in "Fields to sync from HubSpot" invited a pointless configuration: syncing one in only echoes a value Usertour already has, under a second, provider-owned name. The picker now skips that group. The match-field picker is unchanged — the match property lives in that group on purpose.

Follow-up to #492; web `tsc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)