### PR TITLE
chore(hubspot): the production callback lives on the dashboard host

### DIFF
--- a/integrations/hubspot/src/app/app-hsmeta.json
+++ b/integrations/hubspot/src/app/app-hsmeta.json
@@ -9,7 +9,7 @@
     "auth": {
       "type": "oauth",
       "redirectUrls": [
-        "https://api.usertour.io/api/integrations/hubspot/oauth/callback",
+        "https://app.usertour.io/api/integrations/hubspot/oauth/callback",
         "https://staging.usertour.io/api/integrations/hubspot/oauth/callback",
         "http://localhost:5174/api/integrations/hubspot/oauth/callback"
       ],


### PR DESCRIPTION
The dashboard's API is served under app.usertour.io; api.usertour.io is the SDK's host. The OAuth callback must sit on the host the dashboard sends its GraphQL requests to (the transaction cookie is bound to it), so the registered redirect URL moves from `api.` to `app.`. hsmeta only; app build #19 is deployed with it, and the marketplace listing's Install button URL has been reselected accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)