### PR TITLE
chore(hubspot): the production callback lives on the dashboard host

### DIFF
--- a/integrations/hubspot/src/app/app-hsmeta.json
+++ b/integrations/hubspot/src/app/app-hsmeta.json
@@ -9,7 +9,7 @@
     "auth": {
       "type": "oauth",
       "redirectUrls": [
-        "https://api.usertour.io/api/integrations/hubspot/oauth/callback",
+        "https://app.usertour.io/api/integrations/hubspot/oauth/callback",
         "https://staging.usertour.io/api/integrations/hubspot/oauth/callback",
         "http://localhost:5174/api/integrations/hubspot/oauth/callback"
       ],


### PR DESCRIPTION
Follow-up to #494: the registered HubSpot redirect URL moves from api.usertour.io to app.usertour.io, the host the dashboard's API is served on (#495). hsmeta only; app build #19 is deployed with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)